### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/EmergencyOrderOfProtectionCookCounty/data/questions/op_review.yml
+++ b/docassemble/EmergencyOrderOfProtectionCookCounty/data/questions/op_review.yml
@@ -14,7 +14,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle="full")}
+      ${users[0].name_full()}
   - Edit: users[0].birthdate
     button: |
       **Your birthdate:**
@@ -133,10 +133,10 @@ review:
   - Edit: other_parties[0].name.first
     button: |
       **Person you want an Order of Protection against:**
-      ${other_parties[0].name.full(middle="full")}
+      ${other_parties[0].name_full()}
   - Edit: minor_kids_with_respondent
     button: |
-      **Do you have minor children with ${other_parties[0].name.full(middle="full")}?**
+      **Do you have minor children with ${other_parties[0].name_full()}?**
       ${ word(yesno(minor_kids_with_respondent)) }
 
 
@@ -151,10 +151,10 @@ review:
       * Me
       % endif
       % if protect_shared_kids:
-      * Minor children you have with ${other_parties[0].name.full(middle="full")}
+      * Minor children you have with ${other_parties[0].name_full()}
       % endif
       % if protect_petitioner_kids:
-      * Minor children you **did not** have with ${other_parties[0].name.full(middle="full")}
+      * Minor children you **did not** have with ${other_parties[0].name_full()}
       % endif
       % if protect_dependent_adult:
       * A dependent adult
@@ -171,19 +171,19 @@ review:
     
   - Edit: shared_kids.revisit
     button: |
-      **Your minor children with ${other_parties[0].name.full(middle="full")}: (Edit to change names and details)**
+      **Your minor children with ${other_parties[0].name_full()}: (Edit to change names and details)**
 
       % for my_var in shared_kids:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: minor_kids_with_respondent
 
   - Edit: petitioner_kids.revisit
     button: |
-      **Your minor children **not with** ${other_parties[0].name.full(middle="full")}:**
+      **Your minor children **not with** ${other_parties[0].name_full()}:**
 
       % for my_var in petitioner_kids:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: protect_petitioner_kids
 
@@ -192,26 +192,26 @@ review:
       **Other household members:**
 
       % for my_var in other_hh_members:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: protect_other_hh_members
 
   - Edit: dependent_adult.name.first
     button: |
       **Dependent adult you want to protect:**
-      ${dependent_adult.name.full(middle="full")}
+      ${dependent_adult.name_full()}
     show if: protect_dependent_adult
 
   - Edit: high_risk_adult.name.first
     button: |
       **High risk adult you want to protect:**
-      ${high_risk_adult.name.full(middle="full")}
+      ${high_risk_adult.name_full()}
     show if: protect_high_risk_adult
 
   - Edit: obo_minor.name.first
     button: |
       **Minor child you want to protect:**
-      ${obo_minor.name.full(middle="full")}
+      ${obo_minor.name_full()}
     show if: protect_obo_minor
 
   
@@ -231,7 +231,7 @@ review:
       <h4>Protections</h4>
   - Edit: no_harassment
     button: |
-      **What you want the court to order ${other_parties[0].name.full(middle="full")} to not do:**
+      **What you want the court to order ${other_parties[0].name_full()} to not do:**
       
       % if no_harassment:
       * Harassment
@@ -260,7 +260,7 @@ review:
 
   - Edit: stay_away
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away and have no contact at all times?**
+      **Do you want ${other_parties[0].name_full()} to stay away and have no contact at all times?**
       ${ word(yesno(stay_away)) }
 
   - Edit: hide_address
@@ -281,22 +281,22 @@ review:
       % if residence_remedies == 'exclusive possession':
       I want **exclusive possession** of my residence.
       % elif residence_remedies == 'provide alternate housing':
-      I want ${other_parties[0].name.full(middle="full")} to **provide a different place** for me and the protected people to live.
+      I want ${other_parties[0].name_full()} to **provide a different place** for me and the protected people to live.
       % else:
-      Nothing. I don't want the court to give me exclusive possession or to order ${other_parties[0].name.full(middle="full")} to provide a different place for me and the protected people to live.
+      Nothing. I don't want the court to give me exclusive possession or to order ${other_parties[0].name_full()} to provide a different place for me and the protected people to live.
       % endif    
   - Edit: exclusive_possession_reason
     button: |
       **Why should the court give you exclusive possession of the residence?**
       % if exclusive_possession_reason == 'respondent_no_right_to_stay':
-      I have a right to occupy the residence and ${other_parties[0].name.full(middle="full")} has no right.
+      I have a right to occupy the residence and ${other_parties[0].name_full()} has no right.
       % else:
       Both of us have a right to occupy the residence, but it would be harder on me to leave.
       % endif
     show if: residence_remedies == 'exclusive possession'
   - Edit: no_stay_under_influence
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from and not be at your residence while under the influence?**
+      **Do you want ${other_parties[0].name_full()} to stay away from and not be at your residence while under the influence?**
       ${ word(yesno(no_stay_under_influence)) }
       % if no_stay_under_influence:
       [NEWLINE][NEWLINE]
@@ -305,7 +305,7 @@ review:
     show if: not (stay_away or (residence_remedies == 'exclusive possession') or (residence_remedies == 'provide alternate housing'))
   - Edit: stay_away_jobs
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from where you work?**
+      **Do you want ${other_parties[0].name_full()} to stay away from where you work?**
       ${ word(yesno(stay_away_jobs)) }
   - Edit: hide_work_address
     button: |
@@ -318,7 +318,7 @@ review:
     show if: stay_away_jobs and hide_work_address == False
   - Edit: stay_away_jobs_2
     button: |
-      **Do you have another job you want ${other_parties[0].name.full(middle="full")} to stay away from?**
+      **Do you have another job you want ${other_parties[0].name_full()} to stay away from?**
       ${ word(yesno(stay_away_jobs_2)) }
     show if: stay_away_jobs
   - Edit: hide_work_address_2
@@ -333,7 +333,7 @@ review:
 
   - Edit: stay_away_schools
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from schools or daycares?**
+      **Do you want ${other_parties[0].name_full()} to stay away from schools or daycares?**
       ${ word(yesno(stay_away_schools)) }
   - Edit: schools[0].address
     button: |
@@ -342,7 +342,7 @@ review:
     show if: stay_away_schools
   - Edit: schools[0].hide
     button: |
-      **Do you want to hide information about ${ schools[0].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[0].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[0].hide)) }
     show if: stay_away_schools and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[0].type
@@ -353,7 +353,7 @@ review:
 
   - Edit: stay_away_schools_2
     button: |
-      **Do you have another school you want ${other_parties[0].name.full(middle="full")} to stay away from?**
+      **Do you have another school you want ${other_parties[0].name_full()} to stay away from?**
       ${ word(yesno(stay_away_schools_2)) }
     show if: stay_away_schools
   - Edit: schools[1].address
@@ -363,7 +363,7 @@ review:
     show if: stay_away_schools and stay_away_schools_2
   - Edit: schools[1].hide
     button: |
-      **Do you want to hide information about ${ schools[1].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[1].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[1].hide)) }
     show if: stay_away_schools and stay_away_schools_2 and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[1].type
@@ -374,14 +374,14 @@ review:
   
   - Edit: stay_away_other
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from other places?**
+      **Do you want ${other_parties[0].name_full()} to stay away from other places?**
       ${ word(yesno(stay_away_other)) }
 
       **Is this place a school?**
       ${ word(yesno(other_location_1_is_school)) }
   - Edit: hide_other_address_1
     button: |
-      **Do you want to hide the details of the place you want ${other_parties[0].name.full(middle="full") } to stay away from?**
+      **Do you want to hide the details of the place you want ${other_parties[0].name_full() } to stay away from?**
       ${ word(yesno(hide_other_address_1)) }
     show if: stay_away_other and not other_location_1_is_school
   - Edit: other_locations_hidden_description_1
@@ -402,7 +402,7 @@ review:
     show if: stay_away_other and other_location_1_is_school
   - Edit: schools[2].hide
     button: |
-      **Do you want to hide information about ${ schools[2].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[2].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[2].hide)) }
     show if: stay_away_other and other_location_1_is_school and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[2].type
@@ -413,14 +413,14 @@ review:
   
   - Edit: stay_away_other_2
     button: |
-      **Do you have another place you want ${other_parties[0].name.full(middle="full")} to stay away from?**
+      **Do you have another place you want ${other_parties[0].name_full()} to stay away from?**
       ${ word(yesno(stay_away_other_2)) }
 
       **Is this place a school?**
       ${ word(yesno(other_location_2_is_school)) }
   - Edit: hide_other_address_2
     button: |
-      **Do you want to hide the details of the second place you want ${other_parties[0].name.full(middle="full") } to stay away from?**
+      **Do you want to hide the details of the second place you want ${other_parties[0].name_full() } to stay away from?**
       ${ word(yesno(hide_other_address_2)) }
     show if: stay_away_other_2 and not other_location_2_is_school
   - Edit: other_locations_hidden_description_2
@@ -441,7 +441,7 @@ review:
     show if: stay_away_other_2 and other_location_2_is_school
   - Edit: schools[3].hide
     button: |
-      **Do you want to hide information about ${ schools[3].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[3].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[3].hide)) }
     show if: stay_away_other_2 and other_location_2_is_school and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[3].type
@@ -452,7 +452,7 @@ review:
   
   - Edit: same_school
     button: |
-      **Does ${other_parties[0].name.full(middle="full")} attend the same school as you or other protected people?**
+      **Does ${other_parties[0].name_full()} attend the same school as you or other protected people?**
       ${ word(yesno(same_school)) }
   - Edit: same_school_name
     button: |
@@ -466,7 +466,7 @@ review:
     show if: same_school
   - Edit: parts_of_school
     button: |
-      **Parts of school where ${other_parties[0].name.full(middle="full")} should not go:**
+      **Parts of school where ${other_parties[0].name_full()} should not go:**
       ${ parts_of_school }
     show if: same_school_restrictions
 
@@ -476,17 +476,17 @@ review:
     show if: minor_kids_with_respondent  
   - Edit: primary_caretaker
     button: |
-      **Primary caretaker of the children with ${ other_parties[0].name.full(middle="full") }:**
+      **Primary caretaker of the children with ${ other_parties[0].name_full() }:**
       % if primary_caretaker == "petitioner":
       Me
       % elif primary_caretaker == "respondent":
-      ${ other_parties[0].name.full(middle="full") }
+      ${ other_parties[0].name_full() }
       % else:
-      ${ other_caretaker.name.full(middle="full") }
+      ${ other_caretaker.name_full() }
       % endif
   - Edit: other_caretaker.address.address
     button: |
-      **${other_caretaker.name.full(middle="full")}'s address:**
+      **${other_caretaker.name_full()}'s address:**
       ${ other_caretaker.address.on_one_line(bare=True) }
     show if: primary_caretaker == "other"
   - Edit: court_make_children_decisions
@@ -510,32 +510,32 @@ review:
 
   - Edit: temp_custody_of_children
     button: |
-      **Do you want the court to grant you temporary decisionmaking responsibility (custody) of the children you have with ${other_parties[0].name.full(middle="full")}?**
+      **Do you want the court to grant you temporary decisionmaking responsibility (custody) of the children you have with ${other_parties[0].name_full()}?**
       ${ word(yesno(temp_custody_of_children)) }
 
   - Edit: physical_care_of_children
     button: |
-      **Do you want the court to give you possession of the children you have with ${ other_parties[0].name.full(middle="full") }?**
+      **Do you want the court to give you possession of the children you have with ${ other_parties[0].name_full() }?**
       ${ word(yesno(physical_care_of_children)) }
   - Edit: no_conceal_children
     button: |
-      **Do you want the court to order that ${other_parties[0].name.full(middle="full")} cannot hide or remove the children from Illinois?**
+      **Do you want the court to order that ${other_parties[0].name_full()} cannot hide or remove the children from Illinois?**
       ${ word(yesno(no_conceal_children)) }
   - Edit: no_removal_school
     button: |
-      **Do you want the court to order that ${other_parties[0].name.full(middle="full")} cannot remove the children from your care or from a school or daycare?**
+      **Do you want the court to order that ${other_parties[0].name_full()} cannot remove the children from your care or from a school or daycare?**
       ${ word(yesno(no_removal_school)) }
   - Edit: current_possession_of_children
     button: |
-      **Do you currently have physical care and possession of your children with  ${other_parties[0].name.full(middle="full")}?**
+      **Do you currently have physical care and possession of your children with  ${other_parties[0].name_full()}?**
       ${ word(yesno(current_possession_of_children)) }
   - Edit: return_children_to
     button: |
-      **Who should ${other_parties[0].name.full(middle="full")} return the children to?**
+      **Who should ${other_parties[0].name_full()} return the children to?**
       % if return_children_to == "petitioner":
       Me
       % elif return_children_to == "court":
-      ${other_parties[0].name.full(middle="full")} should bring them to court.
+      ${other_parties[0].name_full()} should bring them to court.
       % else:
       Another person
       % endif
@@ -543,21 +543,21 @@ review:
   - Edit: return_children_to
     button: |
       **Other person children should be returned to:**
-      ${ return_children_other_person.name.full(middle="full") }
+      ${ return_children_other_person.name_full() }
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to == "other"
   - Edit: knows_return_children_details
     button: |
-      **Do you know where you want ${other_parties[0].name.full(middle="full")} to return the children?**
+      **Do you know where you want ${other_parties[0].name_full()} to return the children?**
       ${ word(yesno(knows_return_children_details)) }
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to != "court"
   - Edit: return_children_location.address
     button: |
-      **Where should ${other_parties[0].name.full(middle="full")} return the children to?**
+      **Where should ${other_parties[0].name_full()} return the children to?**
       ${ return_children_location.on_one_line(bare=True) }
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to != "court" and knows_return_children_details == True
   - Edit: appear_with_children_prevent
     button: |
-      **${other_parties[0].name.full(middle="full")} should be ordered to bring the children to court:**
+      **${other_parties[0].name_full()} should be ordered to bring the children to court:**
       
       % if appear_with_children_prevent:
       * To prevent abuse, neglect, removal, or concealment of the children
@@ -566,7 +566,7 @@ review:
       * To return the children to me
       % endif
       % if appear_with_children_exam:
-      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name.full(middle="full")}
+      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name_full()}
       % endif
       % if not appear_with_children_prevent and not appear_with_children_return and not appear_with_children_exam:
       * No reasons entered
@@ -574,12 +574,12 @@ review:
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to == "court"
   - Edit: res_appear_alone
     button: |
-      **Should ${other_parties[0].name.full(middle="full")} be ordered to come to court alone?**
+      **Should ${other_parties[0].name_full()} be ordered to come to court alone?**
       ${ word(yesno(res_appear_alone))}
     show if: minor_kids_with_respondent and (current_possession_of_children == True or ( current_possession_of_children == False and return_children_to != "court" ))
   - Edit: res_appear_alone
     button: |
-      **Why should ${other_parties[0].name.full(middle="full")} be ordered to come to court alone?**
+      **Why should ${other_parties[0].name_full()} be ordered to come to court alone?**
       
       % if appear_alone_prevent:
       * To prevent abuse, neglect, removal, or concealment of the children
@@ -588,7 +588,7 @@ review:
       * To return the children to me
       % endif
       % if appear_alone_exam:
-      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name.full(middle="full")}
+      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name_full()}
       % endif
       % if not appear_alone_prevent and not appear_alone_return and not appear_alone_exam:
       * No reasons entered
@@ -596,10 +596,10 @@ review:
     show if: minor_kids_with_respondent and (current_possession_of_children == True or ( current_possession_of_children == False and return_children_to != "court" )) and res_appear_alone
   - Edit: no_records_no_contact
     button: |
-      **${other_parties[0].name.full(middle="full")} should not have access to the children's records for the following reasons:**
+      **${other_parties[0].name_full()} should not have access to the children's records for the following reasons:**
       
       % if no_records_no_contact:
-      * I am requesting ${other_parties[0].name.full(middle="full")} have no contact with the children.
+      * I am requesting ${other_parties[0].name_full()} have no contact with the children.
       % endif
       % if no_records_hide_address:
       * My address is not listed on the court forms to prevent further abuse.
@@ -614,23 +614,23 @@ review:
     button: |
       **What should the court do about parenting time?**
       % if parenting_time == "deny":
-      Deny ${other_parties[0].name.full(middle="full")} any parenting time
+      Deny ${other_parties[0].name_full()} any parenting time
       % endif 
       % if parenting_time == "restrict":
-      Restrict ${other_parties[0].name.full(middle="full")}'s parenting time
+      Restrict ${other_parties[0].name_full()}'s parenting time
       % endif 
       % if parenting_time == "grant":
-      Grant or allow ${other_parties[0].name.full(middle="full")} parenting time
+      Grant or allow ${other_parties[0].name_full()} parenting time
       % endif 
       % if parenting_time == "reserve":
-      Reserve ${other_parties[0].name.full(middle="full")}'s parenting time until a later hearing
+      Reserve ${other_parties[0].name_full()}'s parenting time until a later hearing
       % endif 
   - Edit: restrict_or_deny_pt_reasons
     button: |
       % if parenting_time == "restrict":
-      **Why do you want to restrict ${other_parties[0].name.full(middle="full")}'s parenting time?**
+      **Why do you want to restrict ${other_parties[0].name_full()}'s parenting time?**
       % else:
-      **Why do you want to deny ${other_parties[0].name.full(middle="full")} any parenting time?**
+      **Why do you want to deny ${other_parties[0].name_full()} any parenting time?**
       % endif  
       
       % if restrict_or_deny_pt_reasons["no_pt_no_abuse"]:
@@ -658,7 +658,7 @@ review:
     show if: parenting_time == "restrict" or parenting_time == "grant"
   - Edit: pt_weekdays
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to have parenting time on weekdays?**
+      **Do you want ${other_parties[0].name_full()} to have parenting time on weekdays?**
       ${ word(yesno(pt_weekdays)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_format == "interview"
   - Edit: pt_weekday_days
@@ -673,7 +673,7 @@ review:
     
   - Edit: pt_weekends
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to have parenting time on weekends?**
+      **Do you want ${other_parties[0].name_full()} to have parenting time on weekends?**
       ${ word(yesno(pt_weekends)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_format == "interview"
   - Edit: pt_weekend_cadence
@@ -703,7 +703,7 @@ review:
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_format == "interview"
   - Edit: pt_supervised
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")}'s parenting time to be supervised?**
+      **Do you want ${other_parties[0].name_full()}'s parenting time to be supervised?**
       ${ word(yesno(pt_supervised)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant")
   - Edit: pt_supervisor_type
@@ -718,7 +718,7 @@ review:
   - Edit: pt_supervisor.name.first
     button: |
       **Adult who will supervise parenting time:**
-      ${ pt_supervisor.name.full(middle="full") }
+      ${ pt_supervisor.name_full() }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_supervised == True and pt_supervisor_type == "person"
   - Edit: pt_visitation_center_name
     button: |
@@ -731,7 +731,7 @@ review:
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_supervised == True and pt_supervisor_type == "agency"
   - Edit: pt_location_identified
     button: |
-      **Do you know where you want ${other_parties[0].name.full(middle="full")}'s parenting time to happen?**
+      **Do you know where you want ${other_parties[0].name_full()}'s parenting time to happen?**
       ${ word(yesno(pt_location_identified)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and ((pt_supervised and pt_supervisor_type == "person") or not pt_supervised)
   - Edit: pt_location_identified
@@ -745,7 +745,7 @@ review:
       % if pt_transportation == "petitioner":
       I will provide transportation.
       % elif pt_transportation == "respondent":
-      ${other_parties[0].name.full(middle="full")} will provide transportation.
+      ${other_parties[0].name_full()} will provide transportation.
       % elif pt_transportation == "other":
       Someone else will provide transportation.
       % else:
@@ -755,7 +755,7 @@ review:
   - Edit: pt_transportation_person.name.first
     button: |
       **Person who will provide transportation to and from parenting time:**
-      ${ pt_transportation_person.name.full(middle="full") }
+      ${ pt_transportation_person.name_full() }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_transportation == "other"
   - Edit: pt_separate_pickup_location
     button: |
@@ -787,7 +787,7 @@ review:
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_separate_return_location == True
   - Edit: pt_immediate_return
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to return the children immediately after parenting time?**
+      **Do you want ${other_parties[0].name_full()} to return the children immediately after parenting time?**
       ${ word(yesno(pt_immediate_return)) }
       % if pt_immediate_return:
       % if pt_return_person_choice == "Me":
@@ -795,7 +795,7 @@ review:
       They should be returned to me.
       % elif pt_return_person_choice == "other":
       
-      They should be returned to ${ pt_return_person.name.full(middle="full")}.
+      They should be returned to ${ pt_return_person.name_full()}.
       % else:
       
       I will identify a return person later.
@@ -822,7 +822,7 @@ review:
    
   - Edit: petitioner_personal_property.revisit
     button: |
-      **Personal property ${other_parties[0].name.full(middle="full")} should return to you:**
+      **Personal property ${other_parties[0].name_full()} should return to you:**
 
       % for my_var in petitioner_personal_property:
       % if my_var.respo_has == True:
@@ -832,22 +832,22 @@ review:
     show if: award_personal_property == True and return_property == True
   - Edit: return_property_reason
     button: |
-      **Why should ${other_parties[0].name.full(middle="full")} return the property?**
+      **Why should ${other_parties[0].name_full()} return the property?**
       % if return_property_reason == "petitioner owns":
       I own the property.
       % elif return_property_reason == "both own":      
       We both own the property, but sharing it would be harder on me. It would put me at risk for abuse or sharing is not practical.
       % else:
-      I am married to ${other_parties[0].name.full(middle="full")}, and we filed a divorce.
+      I am married to ${other_parties[0].name_full()}, and we filed a divorce.
       % endif
     show if: award_personal_property == True and return_property == True
   - Edit: return_property_person
     button: |
-      **Who should ${other_parties[0].name.full(middle="full")} return your property to?**
+      **Who should ${other_parties[0].name_full()} return your property to?**
       % if return_property_person == "petitioner":
       Me
       % else:
-      ${ other_return_property_person.name.full(middle="full") }
+      ${ other_return_property_person.name_full() }
       % endif
     show if: (award_personal_property == True and return_property == True)   
   - Edit: property_transfer_location_cb
@@ -875,7 +875,7 @@ review:
       Law enforcement, ${ property_transfer_police }
       % endif
       % else:
-      ${ other_transfer_property_person.name.full(middle="full") }
+      ${ other_transfer_property_person.name_full() }
       % endif
     show if: award_personal_property == True and return_property == True and property_transfer_location_cb == True and property_transfer_present_cb == True
   - Edit: property_transfer_know_date
@@ -890,11 +890,11 @@ review:
     show if: award_personal_property == True and return_property == True and property_transfer_location_cb and property_transfer_know_date == True
   - Edit: return_respo_property
     button: |
-      **Any personal property ${other_parties[0].name.full(middle="full")} will need returned to them right away?**
+      **Any personal property ${other_parties[0].name_full()} will need returned to them right away?**
       ${ word(yesno(return_respo_property)) }
   - Edit: respo_property
     button: |
-      **Personal property of ${other_parties[0].name.full(middle="full")} that should be returned:**
+      **Personal property of ${other_parties[0].name_full()} that should be returned:**
 
       % if respo_property['clothes'] == True:
       * Clothes
@@ -908,12 +908,12 @@ review:
     show if: (return_respo_property == True)
   - Edit: respo_property_other
     button: |
-      **Other personal property of ${other_parties[0].name.full(middle="full")}:**
+      **Other personal property of ${other_parties[0].name_full()}:**
       ${ respo_property_other }
     show if: (return_respo_property == True and respo_property['other'] == True)
   - Edit: respondent_one_time_entry
     button: |
-      **Should ${other_parties[0].name.full(middle="full")} be allowed to enter the home only one time to get their personal property?**
+      **Should ${other_parties[0].name_full()} be allowed to enter the home only one time to get their personal property?**
       ${ word(yesno(respondent_one_time_entry)) }
   - Edit: res_property_transfer_person
     button: |
@@ -925,7 +925,7 @@ review:
       Law enforcement, ${ res_property_transfer_police }
       % endif
       % else:
-      ${ res_other_transfer_property_person.name.full(middle="full") }
+      ${ res_other_transfer_property_person.name_full() }
       % endif
     show if: respondent_one_time_entry == True
       
@@ -975,13 +975,13 @@ review:
       % elif restrict_property_reason == "both":      
       We both own the property, but not having it would be harder on me. It would put me at risk for abuse or sharing is not practical.
       % else:
-      I am married to ${other_parties[0].name.full(middle="full")}, and we have filed for divorce.
+      I am married to ${other_parties[0].name_full()}, and we have filed for divorce.
       % endif
     show if: restrict_other_property == True
     
   - Edit: restrict_elderly_petitioner_resources
     button: |
-      **Should the court protect an elderly person's resources from  ${other_parties[0].name.full(middle="full")}?**
+      **Should the court protect an elderly person's resources from  ${other_parties[0].name_full()}?**
       % if restrict_elderly_petitioner_resources == "Yes":
       Yes
       % elif restrict_elderly_petitioner_resources == "No":
@@ -995,12 +995,12 @@ review:
       <h4>Other remedies</h4>
   - Edit: temp_child_support
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to pay temporary child support?**
+      **Do you want ${other_parties[0].name_full()} to pay temporary child support?**
       ${ word(yesno(temp_child_support)) }
     show if: minor_kids_with_respondent == True
   - Edit: temp_maintenance
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to pay temporary maintenance?**
+      **Do you want ${other_parties[0].name_full()} to pay temporary maintenance?**
       ${ word(yesno(temp_maintenance)) }
     show if: relationship_se == True or relationship_xs == True
   - Edit: separate_phone_service
@@ -1011,9 +1011,9 @@ review:
     button: |
       **Who is the cell phone account holder?**
       % if phone_account_holder == 'respondent':
-      ${other_parties[0].name.full(middle="full")}
+      ${other_parties[0].name_full()}
       % else:
-      ${ other_phone_account_holder.name.full(middle="full") }
+      ${ other_phone_account_holder.name_full() }
       % endif
     show if: separate_phone_service == True
   - Edit: phone_provider
@@ -1021,7 +1021,7 @@ review:
       **Cell phone account details:**
       
       * Provider: ${ phone_provider }
-      * ${other_parties[0].name.full(middle="full")}'s phone number: ${ phone_number_formatted(billing_phone_number) }
+      * ${other_parties[0].name_full()}'s phone number: ${ phone_number_formatted(billing_phone_number) }
     show if: separate_phone_service == True
   - Edit: cell_numbers.revisit
     button: |
@@ -1034,7 +1034,7 @@ review:
     
   - Edit: expenses_none
     button: |
-      **Losses you want ${other_parties[0].name.full(middle="full")} to pay for:**
+      **Losses you want ${other_parties[0].name_full()} to pay for:**
 
       % if expenses_none:
       * None
@@ -1069,11 +1069,11 @@ review:
       % endif
   - Edit: request_counseling
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to get counseling?**
+      **Do you want ${other_parties[0].name_full()} to get counseling?**
       ${ word(yesno(request_counseling)) }
   - Edit: dv_counseling
     button: |
-      **Counseling you want ${ other_parties[0].name.full(middle="full") } to do:**
+      **Counseling you want ${ other_parties[0].name_full() } to do:**
       
       % if dv_counseling:
       * Domestic violence partner abuse counseling
@@ -1095,22 +1095,22 @@ review:
 
   - Edit: firearms_threat
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} a threat to the physical safety of you or your children?**
+      **Is ${other_parties[0].name_full()} a threat to the physical safety of you or your children?**
       ${ word(yesno(firearms_threat)) }
   - Edit: firearms_relief
     button: |
       **Do you want the court to order any firearms relief?**
 
       % if firearms_relief['surrender']:
-      * I want ${other_parties[0].name.full(middle="full")} to **surrender firearms** to law enforcement.
+      * I want ${other_parties[0].name_full()} to **surrender firearms** to law enforcement.
       % endif
       % if firearms_relief['warrant']:
-      * I want a **search warrant** to be issued so law enforcement can search ${other_parties[0].name.full(middle="full")}'s property and seize fierarms.
+      * I want a **search warrant** to be issued so law enforcement can search ${other_parties[0].name_full()}'s property and seize fierarms.
       % endif
     show if: firearms_threat
   - Edit: intimate_partner
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} a current or former intimate partner?**
+      **Is ${other_parties[0].name_full()} a current or former intimate partner?**
       % if intimate_partner == "Yes":
       Yes
       % elif intimate_partner == "No":
@@ -1124,13 +1124,13 @@ review:
       **Why do you want the court to order a search warrant?**
 
       % if warrant_reasons['threat']:
-      * ${other_parties[0].name.full(middle="full")} is an immediate threat to the physical safety of the people I want to protect.
+      * ${other_parties[0].name_full()} is an immediate threat to the physical safety of the people I want to protect.
       % endif
       % if warrant_reasons['has_guns']:
-      * ${other_parties[0].name.full(middle="full")} has a firearm or firearm parts that could be used to make a firearm.
+      * ${other_parties[0].name_full()} has a firearm or firearm parts that could be used to make a firearm.
       % endif
       % if warrant_reasons['location']:
-      * The firearm or firearm parts are in the residence, vehicle, or other property of ${other_parties[0].name.full(middle="full")}.
+      * The firearm or firearm parts are in the residence, vehicle, or other property of ${other_parties[0].name_full()}.
       % endif
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: warrant_location_list.revisit
@@ -1143,7 +1143,7 @@ review:
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: has_helpful_warrant_info
     button: |
-      **Do you have other information about ${other_parties[0].name.full(middle="full")} that could help law enforcement with the warrant?**
+      **Do you have other information about ${other_parties[0].name_full()} that could help law enforcement with the warrant?**
       ${ word(yesno(has_helpful_warrant_info))}      
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: has_helpful_warrant_info
@@ -1158,13 +1158,13 @@ review:
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: firearms_eop_notice
     button: |
-      **Are you worried that ${other_parties[0].name.full(middle="full")} might hurt you or the people you want to protect when they learn about the Order of Protection?**
+      **Are you worried that ${other_parties[0].name_full()} might hurt you or the people you want to protect when they learn about the Order of Protection?**
       ${ word(yesno(firearms_eop_notice))}
     show if: firearms_threat and firearms_relief['surrender'] or firearms_relief['warrant']
     
   - Edit: misc_remedies_text
     button: |
-      **What else do you want the court to order ${other_parties[0].name.full(middle="full")} to do or to stop doing?**
+      **What else do you want the court to order ${other_parties[0].name_full()} to do or to stop doing?**
       % if misc_remedies_text == "":
       Nothing
       % else:
@@ -1181,7 +1181,7 @@ review:
       <h4>About the person who caused abuse</h4>
   - Edit: knows_respondent_dob
     button: |
-      **What you know about ${other_parties[0].name.full(middle="full")}'s birthdate?**[NEWLINE]
+      **What you know about ${other_parties[0].name_full()}'s birthdate?**[NEWLINE]
       % if knows_respondent_dob == "exact" and other_parties[0].birthdate != "":
       The exact date: ${ other_parties[0].birthdate }
       % elif knows_respondent_dob == "some":
@@ -1192,7 +1192,7 @@ review:
 
   - Edit: respondent_parent_help
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")}'s parent or guardian help them follow the Order of Protection?**
+      **Do you want ${other_parties[0].name_full()}'s parent or guardian help them follow the Order of Protection?**
       % if respondent_parent_help == "Yes":
       Yes
       % elif respondent_parent_help == "No":
@@ -1207,13 +1207,13 @@ review:
     show if: respondent_parent_help == "Yes"
   - Edit: respondent_parent_order
     button: |
-      **What should ${other_parties[0].name.full(middle="full")}'s parent or guardian be ordered to do?**
+      **What should ${other_parties[0].name_full()}'s parent or guardian be ordered to do?**
       ${ respondent_parent_order }
     show if: respondent_parent_help == "Yes"
 
   - Edit: other_parties[0].gender
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s gender?**
+      **What is ${other_parties[0].name_full()}'s gender?**
       % if other_parties[0].gender == "":
       None entered
       % endif
@@ -1228,7 +1228,7 @@ review:
       % endif
   - Edit: other_parties[0].gender_cook
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s gender identity (confidential)?**
+      **What is ${other_parties[0].name_full()}'s gender identity (confidential)?**
       
       % if other_parties[0].gender_cook.all_false():
       * None entered
@@ -1258,7 +1258,7 @@ review:
     show if: trial_court_index == -1
   - Edit: respondent_sex_at_birth
     button: |
-      **${other_parties[0].name.full(middle="full")}'s sex assigned at birth (condfidential):**
+      **${other_parties[0].name_full()}'s sex assigned at birth (condfidential):**
       % if respondent_sex_at_birth == "None":
       None entered
       % else:
@@ -1272,7 +1272,7 @@ review:
     
   - Edit: other_parties[0].race
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s race?**
+      **What is ${other_parties[0].name_full()}'s race?**
       % if other_parties[0].race == 'other':
       ${ respondent_race_other }
       % else:
@@ -1281,7 +1281,7 @@ review:
 
   - Edit: other_parties[0].height_feet
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s height?**
+      **What is ${other_parties[0].name_full()}'s height?**
       % if other_parties[0].height_feet > 1:
       ${ other_parties[0].height_feet } feet
       % if other_parties[0].height_inches > 0:
@@ -1292,7 +1292,7 @@ review:
       % endif
   - Edit: other_parties[0].weight
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s weight?**
+      **What is ${other_parties[0].name_full()}'s weight?**
       % if other_parties[0].weight > 0:
       ${ other_parties[0].weight } pounds
       % else:
@@ -1300,7 +1300,7 @@ review:
       % endif
   - Edit: other_parties[0].skin
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s skin color?**
+      **What is ${other_parties[0].name_full()}'s skin color?**
       % if other_parties[0].skin == 'other':
       ${ respondent_skin_other }
       % else:
@@ -1309,7 +1309,7 @@ review:
     show if: trial_court_index == -1
   - Edit: other_parties[0].hair
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s hair color?**
+      **What is ${other_parties[0].name_full()}'s hair color?**
       % if other_parties[0].hair != "":
       ${ other_parties[0].hair }
       % else:
@@ -1317,7 +1317,7 @@ review:
       % endif
   - Edit: other_parties[0].eyes
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s eye color?**
+      **What is ${other_parties[0].name_full()}'s eye color?**
       % if other_parties[0].eyes != "":
       ${ other_parties[0].eyes }
       % else:
@@ -1325,7 +1325,7 @@ review:
       % endif
   - Edit: other_parties[0].tattoos
     button: |
-      **Other things about ${other_parties[0].name.full(middle="full")}'s appearance:**
+      **Other things about ${other_parties[0].name_full()}'s appearance:**
       % if other_parties[0].tattoos != "":
       ${ other_parties[0].tattoos }
       % else:
@@ -1333,7 +1333,7 @@ review:
       % endif
   - Edit: other_parties[0].glasses
     button: |
-      **Does ${other_parties[0].name.full(middle="full")} wear glasses?**
+      **Does ${other_parties[0].name_full()} wear glasses?**
       % if other_parties[0].glasses is not None:
       ${ other_parties[0].glasses }
       % else:
@@ -1343,12 +1343,12 @@ review:
       
   - Edit: other_parties[0].alias_names
     button: |
-      **Other names ${other_parties[0].name.full(middle="full")} has used:**
+      **Other names ${other_parties[0].name_full()} has used:**
       ${ other_parties[0].alias_names }
     show if: trial_court_index == -1
   - Edit: respondent_on_probation
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} on court-ordered probation?**
+      **Is ${other_parties[0].name_full()} on court-ordered probation?**
       % if respondent_on_probation == "Yes":
       Yes
       % elif respondent_on_probation == "No":
@@ -1364,7 +1364,7 @@ review:
     show if: respondent_on_probation == "Yes" and trial_court_index == -1
   - Edit: caution_reasons
     button : |
-      **Reasons sheriff should use caution when approaching ${other_parties[0].name.full(middle="full")}:**
+      **Reasons sheriff should use caution when approaching ${other_parties[0].name_full()}:**
       
       % if not any(caution_reasons):
       * None entered
@@ -1397,15 +1397,15 @@ review:
       
   - Edit: knows_respondent_home
     button: |
-      **Do you know ${other_parties[0].name.full(middle="full")}'s current home address?**
+      **Do you know ${other_parties[0].name_full()}'s current home address?**
       ${ word(yesno(knows_respondent_home)) }
   - Edit: knows_respondent_home_last
     button: |
-      **Do you know ${other_parties[0].name.full(middle="full")}'s last known address?**
+      **Do you know ${other_parties[0].name_full()}'s last known address?**
       ${ word(yesno(knows_respondent_home_last)) }      
   - Edit: other_parties[0].address.address
     button: |
-      **${other_parties[0].name.full(middle="full")}'s home address:**
+      **${other_parties[0].name_full()}'s home address:**
       % if other_parties[0].address.address != "":
       % if knows_respondent_home:
       ${ other_parties[0].address.on_one_line(bare=True) }
@@ -1417,7 +1417,7 @@ review:
       % endif
   - Edit: other_parties[0].phone_number
     button: |
-      **${other_parties[0].name.full(middle="full")}'s home phone number:**
+      **${other_parties[0].name_full()}'s home phone number:**
       % if other_parties[0].phone_number != "":
       ${ phone_number_formatted(other_parties[0].phone_number) }      
       % else:
@@ -1425,7 +1425,7 @@ review:
       % endif
   - Edit: other_parties[0].mobile_number
     button: |
-      **${other_parties[0].name.full(middle="full")}'s cell number:**
+      **${other_parties[0].name_full()}'s cell number:**
       % if other_parties[0].mobile_number != "":
       ${ phone_number_formatted(other_parties[0].mobile_number) }      
       % else:
@@ -1433,7 +1433,7 @@ review:
       % endif
   - Edit: other_parties[0].email
     button: |
-      **${other_parties[0].name.full(middle="full")}'s email:**
+      **${other_parties[0].name_full()}'s email:**
       % if other_parties[0].email != "":
       ${ other_parties[0].email }
       % else:
@@ -1441,20 +1441,20 @@ review:
       % endif
   - Edit: respondent_on_social_media
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} active on social media?**
+      **Is ${other_parties[0].name_full()} active on social media?**
       ${ respondent_on_social_media }      
   - Edit: respondent_social_media_accounts
     button: |
-      **${other_parties[0].name.full(middle="full")}'s social media accounts:**
+      **${other_parties[0].name_full()}'s social media accounts:**
       ${ respondent_social_media_accounts }
     show if: respondent_on_social_media == 'Yes'
   - Edit: knows_respondent_work
     button: |
-      **Do you know ${other_parties[0].name.full(middle="full")}'s work info?**
+      **Do you know ${other_parties[0].name_full()}'s work info?**
       ${ word(yesno(knows_respondent_work)) }
   - Edit: other_parties[0].work_address.address
     button: |
-      **${other_parties[0].name.full(middle="full")}'s work info:**
+      **${other_parties[0].name_full()}'s work info:**
       % if knows_respondent_work:
       ${ other_parties[0].employer + ", " + other_parties[0].work_address.on_one_line(bare=True) }
       % else:
@@ -1462,7 +1462,7 @@ review:
       % endif
   - Edit: respondent_work_type
     button: |
-      **${other_parties[0].name.full(middle="full")}'s occupation or type of work:**
+      **${other_parties[0].name_full()}'s occupation or type of work:**
       % if knows_respondent_work and respondent_work_type != "":
       ${ respondent_work_type }
       % else:
@@ -1472,7 +1472,7 @@ review:
 
   - Edit: cook_vehicle_color
     button: |
-      **Details on ${other_parties[0].name.full(middle="full")}'s car:**
+      **Details on ${other_parties[0].name_full()}'s car:**
 
       % if respondent_car_make == "":
       * Car make: None entered
@@ -1509,7 +1509,7 @@ review:
 
   - Edit: other_parties[0].work_hours
     button: |
-      **${other_parties[0].name.full(middle="full")}'s work schedule:**
+      **${other_parties[0].name_full()}'s work schedule:**
       % if knows_respondent_work and other_parties[0].work_hours != "":
       ${ other_parties[0].work_hours }
       % else:
@@ -1518,12 +1518,12 @@ review:
 
   - Edit: has_other_ops
     button: |
-      **Are there other Orders of Protection against ${other_parties[0].name.full(middle="full")}?**
+      **Are there other Orders of Protection against ${other_parties[0].name_full()}?**
       ${ has_other_ops }
       
   - Edit: other_ops.revisit
     button: |
-      **Other Orders of Protection against ${other_parties[0].name.full(middle="full")}: (Edit to change details)**
+      **Other Orders of Protection against ${other_parties[0].name_full()}: (Edit to change details)**
 
       % for my_var in other_ops:
         * ${ my_var.name.text } in ${ my_var.year }
@@ -1532,12 +1532,12 @@ review:
 
   - Edit: has_other_cases
     button: |
-      **Are there other cases with ${other_parties[0].name.full(middle="full")}?**
+      **Are there other cases with ${other_parties[0].name_full()}?**
       ${ has_other_cases }
       
   - Edit: other_cases.revisit
     button: |
-      **Other cases with ${other_parties[0].name.full(middle="full")}: (Edit to change details)**
+      **Other cases with ${other_parties[0].name_full()}: (Edit to change details)**
 
       % for my_var in other_cases:
         * ${ my_var.name.text } in ${ my_var.year }
@@ -1549,7 +1549,7 @@ review:
       <h4>Filing and service details</h4>
   - Edit: service_method
     button: |
-      **How do you want ${other_parties[0].name.full(middle="full")} to be served?**
+      **How do you want ${other_parties[0].name_full()} to be served?**
       % if service_method == "sheriff":
       By the sheriff
       % elif service_method == "sps":
@@ -1562,7 +1562,7 @@ review:
 
   - Edit: service_address_choice
     button: |
-      **Where can ${other_parties[0].name.full(middle="full")} be found for service?**
+      **Where can ${other_parties[0].name_full()} be found for service?**
       % if service_address_choice == "other":
       At another address
       % else:
@@ -1575,11 +1575,11 @@ review:
     show if: service_address_choice == "other"
   - Edit: has_second_service_address
     button: |
-      **Do you know another location where ${other_parties[0].name.full(middle="full")} can be found for service?**
+      **Do you know another location where ${other_parties[0].name_full()} can be found for service?**
       ${ word(yesno(has_second_service_address)) }
   - Edit: second_service_address_choice
     button: |
-      **Where else can ${other_parties[0].name.full(middle="full")} be found for service?**
+      **Where else can ${other_parties[0].name_full()} be found for service?**
       % if second_service_address_choice == "other":
       At another address
       % else:
@@ -1593,23 +1593,23 @@ review:
     show if: has_second_service_address and second_service_address_choice == "other"
   - Edit: other_parties[0].phone_number_alt
     button: |
-      **${other_parties[0].name.full(middle="full")}'s other contact info:**
+      **${other_parties[0].name_full()}'s other contact info:**
   
       % if other_parties[0].phone_number_alt != "":
-      * ${other_parties[0].name.full(middle="full")}'s alternate phone: ${ phone_number_formatted(other_parties[0].phone_number_alt) }
+      * ${other_parties[0].name_full()}'s alternate phone: ${ phone_number_formatted(other_parties[0].phone_number_alt) }
       % else:
-      * ${other_parties[0].name.full(middle="full")}'s alternate phone: None entered
+      * ${other_parties[0].name_full()}'s alternate phone: None entered
       % endif
       % if other_parties[0].email_alt != "":
-      * ${other_parties[0].name.full(middle="full")}'s alternate email: ${ other_parties[0].email_alt }
+      * ${other_parties[0].name_full()}'s alternate email: ${ other_parties[0].email_alt }
       % else:
-      * ${other_parties[0].name.full(middle="full")}'s alternate email: None entered
+      * ${other_parties[0].name_full()}'s alternate email: None entered
       % endif
     show if: has_second_service_address
       
   - Edit: service_information
     button: |
-      **Additional information to help serve court papers on ${other_parties[0].name.full(middle="full")}:**
+      **Additional information to help serve court papers on ${other_parties[0].name_full()}:**
       ${ service_information }
     show if: trial_court_index == -1
       
@@ -1635,7 +1635,7 @@ review:
     
   - Edit: previous_cook_case_type
     button: |
-      **Previous Cook County case involving ${other_parties[0].name.full(middle="full")}:**
+      **Previous Cook County case involving ${other_parties[0].name_full()}:**
       ${ previous_cook_case_type.capitalize() }
     show if: trial_court_index == -1
   - Edit: previous_cook_case_date
@@ -1681,7 +1681,7 @@ review:
 id: shared kids revisit review screen
 continue button field: shared_kids.revisit
 question: |
-  Edit the minor children you have with ${other_parties[0].name.full(middle="full")}
+  Edit the minor children you have with ${other_parties[0].name_full()}
 subquestion: |
   ${ shared_kids.table }
   
@@ -1693,7 +1693,7 @@ table: shared_kids.table
 rows: shared_kids
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
   - Birthdate: |
       row_item.birthdate if defined("row_item.birthdate") else ""
   - Details (including residence, parentage, protected by order): |
@@ -1706,12 +1706,12 @@ id: shared kids details review screen
 continue button field: x.review_shared_child_details
 generic object: ALIndividual
 question: |
-  Edit ${ x.name.full(middle="full") }'s information
+  Edit ${ x.name_full() }'s information
 review: 
   - Edit: x.name.first
     button: |
       **Name:**
-      ${ x.name.full(middle="full")  }
+      ${ x.name_full()  }
   - Edit: x.birthdate
     button: |
       **Birthdate:**
@@ -1732,7 +1732,7 @@ review:
       % endif
   - Edit: x.res_parentage
     button: |
-      **Has ${other_parties[0].name.full(middle="full")}'s legal parentage been established?**
+      **Has ${other_parties[0].name_full()}'s legal parentage been established?**
       % if x.res_parentage == True:
       Yes
       % elif x.res_parentage == False:
@@ -1749,7 +1749,7 @@ continue button label: Next
 id: petitioner kids revisit review screen
 continue button field: petitioner_kids.revisit
 question: |
-  Edit your minor children you **do not** have with ${other_parties[0].name.full(middle="full")} you want protected by this order
+  Edit your minor children you **do not** have with ${other_parties[0].name_full()} you want protected by this order
 subquestion: |
   ${ petitioner_kids.table }
 
@@ -1759,7 +1759,7 @@ table: petitioner_kids.table
 rows: petitioner_kids
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 delete buttons: True
@@ -1779,7 +1779,7 @@ table: other_hh_members.table
 rows: other_hh_members
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 delete buttons: True
@@ -1834,7 +1834,7 @@ continue button label: Next
 id: other ops revisit review screen
 continue button field: other_ops.revisit
 question: |
-  Edit the other Orders of Protection against ${other_parties[0].name.full(middle="full")}
+  Edit the other Orders of Protection against ${other_parties[0].name_full()}
 subquestion: |
   ${ other_ops.table }
 
@@ -1883,7 +1883,7 @@ continue button label: Next
 id: other cases revisit review screen
 continue button field: other_cases.revisit
 question: |
-  Edit the other court cases with ${other_parties[0].name.full(middle="full")}
+  Edit the other court cases with ${other_parties[0].name_full()}
 subquestion: |
   ${ other_cases.table }
 
@@ -1945,7 +1945,7 @@ rows: petitioner_personal_property
 columns:
   - Item name: |
       row_item.name.text if defined("row_item.name.text") else ""
-  - ${other_parties[0].name.full(middle="full")} should return: |
+  - ${other_parties[0].name_full()} should return: |
       word(yesno(row_item.respo_has)) if defined("row_item.respo_has") else ""
   - Edit: |
       action_button_html(url_action(row_item.attr_name("name.text")), label="Edit", icon="pencil-alt")
@@ -1964,7 +1964,7 @@ review:
       ${ x.name.text  }
   - Edit: x.respo_has
     button: |
-      **${other_parties[0].name.full(middle="full")} should return:**
+      **${other_parties[0].name_full()} should return:**
       ${ word(yesno(x.respo_has)) } 
 continue button label: Next
 ---
@@ -2028,7 +2028,7 @@ columns:
       row_item.on_one_line(bare=True) if defined("row_item.address") else ""
   - Description: |
       row_item.description if defined("row_item.description") else ""
-  - Details (including when ${other_parties[0].name.full(middle="full")} is there, others at the location): |
+  - Details (including when ${other_parties[0].name_full()} is there, others at the location): |
       action_button_html(url_action(row_item.attr_name("address")), label="Edit", icon="pencil-alt")
 delete buttons: True
 confirm: True
@@ -2044,7 +2044,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle="full")}
+      ${users[0].name_full()}
   - Edit: users[0].birthdate
     button: |
       **Your birthdate:**
@@ -2163,17 +2163,17 @@ review:
   - Edit: other_parties[0].name.first
     button: |
       **Person you want an Order of Protection against:**
-      ${other_parties[0].name.full(middle="full")}
+      ${other_parties[0].name_full()}
   - Edit: minor_kids_with_respondent
     button: |
-      **Do you have minor children with ${other_parties[0].name.full(middle="full")}?**
+      **Do you have minor children with ${other_parties[0].name_full()}?**
       ${ word(yesno(minor_kids_with_respondent)) }
   - Edit: shared_kids.revisit
     button: |
-      **Your minor children with ${other_parties[0].name.full(middle="full")}: (Edit to change names and details)**
+      **Your minor children with ${other_parties[0].name_full()}: (Edit to change names and details)**
 
       % for my_var in shared_kids:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: minor_kids_with_respondent
 
@@ -2194,10 +2194,10 @@ review:
       * Me
       % endif
       % if protect_shared_kids:
-      * Minor children you have with ${other_parties[0].name.full(middle="full")}
+      * Minor children you have with ${other_parties[0].name_full()}
       % endif
       % if protect_petitioner_kids:
-      * Minor children you **did not** have with ${other_parties[0].name.full(middle="full")}
+      * Minor children you **did not** have with ${other_parties[0].name_full()}
       % endif
       % if protect_dependent_adult:
       * A dependent adult
@@ -2214,19 +2214,19 @@ review:
     
   - Edit: shared_kids.revisit
     button: |
-      **Your minor children with ${other_parties[0].name.full(middle="full")}: (Edit to change names and details)**
+      **Your minor children with ${other_parties[0].name_full()}: (Edit to change names and details)**
 
       % for my_var in shared_kids:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: minor_kids_with_respondent
 
   - Edit: petitioner_kids.revisit
     button: |
-      **Your minor children **not with** ${other_parties[0].name.full(middle="full")}:**
+      **Your minor children **not with** ${other_parties[0].name_full()}:**
 
       % for my_var in petitioner_kids:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: protect_petitioner_kids
 
@@ -2235,26 +2235,26 @@ review:
       **Other household members:**
 
       % for my_var in other_hh_members:
-        * ${ my_var.name.full(middle="full") }
+        * ${ my_var.name_full() }
       % endfor
     show if: protect_other_hh_members
 
   - Edit: dependent_adult.name.first
     button: |
       **Dependent adult you want to protect:**
-      ${dependent_adult.name.full(middle="full")}
+      ${dependent_adult.name_full()}
     show if: protect_dependent_adult
 
   - Edit: high_risk_adult.name.first
     button: |
       **High risk adult you want to protect:**
-      ${high_risk_adult.name.full(middle="full")}
+      ${high_risk_adult.name_full()}
     show if: protect_high_risk_adult
 
   - Edit: obo_minor.name.first
     button: |
       **Minor child you want to protect:**
-      ${obo_minor.name.full(middle="full")}
+      ${obo_minor.name_full()}
     show if: protect_obo_minor
 
 ---
@@ -2285,7 +2285,7 @@ subquestion: |
 review:
   - Edit: no_harassment
     button: |
-      **What you want the court to order ${other_parties[0].name.full(middle="full")} to not do:**
+      **What you want the court to order ${other_parties[0].name_full()} to not do:**
       
       % if no_harassment:
       * Harassment
@@ -2314,7 +2314,7 @@ review:
 
   - Edit: stay_away
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away and have no contact at all times?**
+      **Do you want ${other_parties[0].name_full()} to stay away and have no contact at all times?**
       ${ word(yesno(stay_away)) }
 
   - Edit: hide_address
@@ -2335,22 +2335,22 @@ review:
       % if residence_remedies == 'exclusive possession':
       I want **exclusive possession** of my residence.
       % elif residence_remedies == 'provide alternate housing':
-      I want ${other_parties[0].name.full(middle="full")} to **provide a different place** for me and the protected people to live.
+      I want ${other_parties[0].name_full()} to **provide a different place** for me and the protected people to live.
       % else:
-      Nothing. I don't want the court to give me exclusive possession or to order ${other_parties[0].name.full(middle="full")} to provide a different place for me and the protected people to live.
+      Nothing. I don't want the court to give me exclusive possession or to order ${other_parties[0].name_full()} to provide a different place for me and the protected people to live.
       % endif    
   - Edit: exclusive_possession_reason
     button: |
       **Why should the court give you exclusive possession of the residence?**
       % if exclusive_possession_reason == 'respondent_no_right_to_stay':
-      I have a right to occupy the residence and ${other_parties[0].name.full(middle="full")} has no right.
+      I have a right to occupy the residence and ${other_parties[0].name_full()} has no right.
       % else:
       Both of us have a right to occupy the residence, but it would be harder on me to leave.
       % endif
     show if: residence_remedies == 'exclusive possession'
   - Edit: no_stay_under_influence
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from and not be at your residence while under the influence?**
+      **Do you want ${other_parties[0].name_full()} to stay away from and not be at your residence while under the influence?**
       ${ word(yesno(no_stay_under_influence)) }
       % if no_stay_under_influence:
       [NEWLINE][NEWLINE]
@@ -2359,7 +2359,7 @@ review:
     show if: not (stay_away or (residence_remedies == 'exclusive possession') or (residence_remedies == 'provide alternate housing'))
   - Edit: stay_away_jobs
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from where you work?**
+      **Do you want ${other_parties[0].name_full()} to stay away from where you work?**
       ${ word(yesno(stay_away_jobs)) }
   - Edit: hide_work_address
     button: |
@@ -2372,7 +2372,7 @@ review:
     show if: stay_away_jobs and hide_work_address == False
   - Edit: stay_away_jobs_2
     button: |
-      **Do you have another job you want ${other_parties[0].name.full(middle="full")} to stay away from?**
+      **Do you have another job you want ${other_parties[0].name_full()} to stay away from?**
       ${ word(yesno(stay_away_jobs_2)) }
     show if: stay_away_jobs
   - Edit: hide_work_address_2
@@ -2387,7 +2387,7 @@ review:
   
   - Edit: stay_away_schools
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from schools or daycares?**
+      **Do you want ${other_parties[0].name_full()} to stay away from schools or daycares?**
       ${ word(yesno(stay_away_schools)) }
   - Edit: schools[0].address
     button: |
@@ -2396,7 +2396,7 @@ review:
     show if: stay_away_schools
   - Edit: schools[0].hide
     button: |
-      **Do you want to hide information about ${ schools[0].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[0].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[0].hide)) }
     show if: stay_away_schools and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[0].type
@@ -2407,7 +2407,7 @@ review:
 
   - Edit: stay_away_schools_2
     button: |
-      **Do you have another school you want ${other_parties[0].name.full(middle="full")} to stay away from?**
+      **Do you have another school you want ${other_parties[0].name_full()} to stay away from?**
       ${ word(yesno(stay_away_schools_2)) }
     show if: stay_away_schools
   - Edit: schools[1].address
@@ -2417,7 +2417,7 @@ review:
     show if: stay_away_schools and stay_away_schools_2
   - Edit: schools[1].hide
     button: |
-      **Do you want to hide information about ${ schools[1].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[1].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[1].hide)) }
     show if: stay_away_schools and stay_away_schools_2 and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[1].type
@@ -2428,7 +2428,7 @@ review:
   
   - Edit: stay_away_other
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to stay away from other places?**
+      **Do you want ${other_parties[0].name_full()} to stay away from other places?**
       ${ word(yesno(stay_away_other)) }
 
   - Edit: other_location_1_is_school
@@ -2438,7 +2438,7 @@ review:
     show if: stay_away_other
   - Edit: hide_other_address_1
     button: |
-      **Do you want to hide the details of the place you want ${other_parties[0].name.full(middle="full") } to stay away from?**
+      **Do you want to hide the details of the place you want ${other_parties[0].name_full() } to stay away from?**
       ${ word(yesno(hide_other_address_1)) }
     show if: stay_away_other and not other_location_1_is_school
   - Edit: other_locations_hidden_description_1
@@ -2459,7 +2459,7 @@ review:
     show if: stay_away_other and other_location_1_is_school
   - Edit: schools[2].hide
     button: |
-      **Do you want to hide information about ${ schools[2].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[2].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[2].hide)) }
     show if: stay_away_other and other_location_1_is_school and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[2].type
@@ -2470,7 +2470,7 @@ review:
   
   - Edit: stay_away_other_2
     button: |
-      **Do you have another place you want ${other_parties[0].name.full(middle="full")} to stay away from?**
+      **Do you have another place you want ${other_parties[0].name_full()} to stay away from?**
       ${ word(yesno(stay_away_other_2)) }
   - Edit: other_location_2_is_school
     button: |
@@ -2479,7 +2479,7 @@ review:
     show if: stay_away_other_2
   - Edit: hide_other_address_2
     button: |
-      **Do you want to hide the details of the second place you want ${other_parties[0].name.full(middle="full") } to stay away from?**
+      **Do you want to hide the details of the second place you want ${other_parties[0].name_full() } to stay away from?**
       ${ word(yesno(hide_other_address_2)) }
     show if: stay_away_other_2 and not other_location_2_is_school
   - Edit: other_locations_hidden_description_2
@@ -2500,7 +2500,7 @@ review:
     show if: stay_away_other_2 and other_location_2_is_school
   - Edit: schools[3].hide
     button: |
-      **Do you want to hide information about ${ schools[3].name } from  ${other_parties[0].name.full(middle="full")}?**
+      **Do you want to hide information about ${ schools[3].name } from  ${other_parties[0].name_full()}?**
       ${ word(yesno(schools[3].hide)) }
     show if: stay_away_other_2 and other_location_2_is_school and (minor_kids_with_respondent or protect_petitioner_kids)
   - Edit: schools[3].type
@@ -2511,7 +2511,7 @@ review:
   
   - Edit: same_school
     button: |
-      **Does ${other_parties[0].name.full(middle="full")} attend the same school as you or other protected people?**
+      **Does ${other_parties[0].name_full()} attend the same school as you or other protected people?**
       ${ word(yesno(same_school)) }
   - Edit: same_school_name
     button: |
@@ -2525,7 +2525,7 @@ review:
     show if: same_school
   - Edit: parts_of_school
     button: |
-      **Parts of school where ${other_parties[0].name.full(middle="full")} should not go:**
+      **Parts of school where ${other_parties[0].name_full()} should not go:**
       ${ parts_of_school }
     show if: same_school_restrictions
 
@@ -2540,21 +2540,21 @@ subquestion: |
 review: 
   - Edit: minor_kids_with_respondent
     button: |
-      **Do you have minor children with ${other_parties[0].name.full(middle="full")}?**
+      **Do you have minor children with ${other_parties[0].name_full()}?**
       ${ word(yesno(minor_kids_with_respondent)) }
   - Edit: primary_caretaker
     button: |
-      **Primary caretaker of the children with ${ other_parties[0].name.full(middle="full") }:**
+      **Primary caretaker of the children with ${ other_parties[0].name_full() }:**
       % if primary_caretaker == "petitioner":
       Me
       % elif primary_caretaker == "respondent":
-      ${ other_parties[0].name.full(middle="full") }
+      ${ other_parties[0].name_full() }
       % else:
-      ${ other_caretaker.name.full(middle="full") }
+      ${ other_caretaker.name_full() }
       % endif
   - Edit: other_caretaker.address.address
     button: |
-      **${other_caretaker.name.full(middle="full")}'s address:**
+      **${other_caretaker.name_full()}'s address:**
       ${ other_caretaker.address.on_one_line(bare=True) }
     show if: primary_caretaker == "other"
   - Edit: court_make_children_decisions
@@ -2578,32 +2578,32 @@ review:
 
   - Edit: temp_custody_of_children
     button: |
-      **Do you want the court to grant you temporary decisionmaking responsibility (custody) of the children you have with ${other_parties[0].name.full(middle="full")}?**
+      **Do you want the court to grant you temporary decisionmaking responsibility (custody) of the children you have with ${other_parties[0].name_full()}?**
       ${ word(yesno(temp_custody_of_children)) }
   - Edit: physical_care_of_children
     button: |
-      **Do you want the court to give you possession of the children you have with ${ other_parties[0].name.full(middle="full") }?**
+      **Do you want the court to give you possession of the children you have with ${ other_parties[0].name_full() }?**
       ${ word(yesno(physical_care_of_children)) }
   - Edit: no_conceal_children
     button: |
-      **Do you want the court to order that ${other_parties[0].name.full(middle="full")} cannot hide or remove the children from Illinois?**
+      **Do you want the court to order that ${other_parties[0].name_full()} cannot hide or remove the children from Illinois?**
       ${ word(yesno(no_conceal_children)) }
   - Edit: no_removal_school
     button: |
-      **Do you want the court to order that ${other_parties[0].name.full(middle="full")} cannot remove the children from your care or from a school or daycare?**
+      **Do you want the court to order that ${other_parties[0].name_full()} cannot remove the children from your care or from a school or daycare?**
       ${ word(yesno(no_removal_school)) }
 
   - Edit: current_possession_of_children
     button: |
-      **Do you currently have physical care and possession of your children with  ${other_parties[0].name.full(middle="full")}?**
+      **Do you currently have physical care and possession of your children with  ${other_parties[0].name_full()}?**
       ${ word(yesno(current_possession_of_children)) }
   - Edit: return_children_to
     button: |
-      **Who should ${other_parties[0].name.full(middle="full")} return the children to?**
+      **Who should ${other_parties[0].name_full()} return the children to?**
       % if return_children_to == "petitioner":
       Me
       % elif return_children_to == "court":
-      ${other_parties[0].name.full(middle="full")} should bring them to court.
+      ${other_parties[0].name_full()} should bring them to court.
       % else:
       Another person
       % endif
@@ -2611,21 +2611,21 @@ review:
   - Edit: return_children_to
     button: |
       **Other person children should be returned to:**
-      ${ return_children_other_person.name.full(middle="full") }
+      ${ return_children_other_person.name_full() }
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to == "other"
   - Edit: knows_return_children_details
     button: |
-      **Do you know where you want ${other_parties[0].name.full(middle="full")} to return the children?**
+      **Do you know where you want ${other_parties[0].name_full()} to return the children?**
       ${ word(yesno(knows_return_children_details)) }
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to != "court"
   - Edit: return_children_location.address
     button: |
-      **Where should ${other_parties[0].name.full(middle="full")} return the children to?**
+      **Where should ${other_parties[0].name_full()} return the children to?**
       ${ return_children_location.on_one_line(bare=True) }
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to != "court" and knows_return_children_details == True
   - Edit: appear_with_children_prevent
     button: |
-      **${other_parties[0].name.full(middle="full")} should be ordered to bring the children to court:**
+      **${other_parties[0].name_full()} should be ordered to bring the children to court:**
       
       % if appear_with_children_prevent:
       * To prevent abuse, neglect, removal, or concealment of the children
@@ -2634,7 +2634,7 @@ review:
       * To return the children to me
       % endif
       % if appear_with_children_exam:
-      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name.full(middle="full")}
+      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name_full()}
       % endif
       % if not appear_with_children_prevent and not appear_with_children_return and not appear_with_children_exam:
       * No reasons entered
@@ -2642,12 +2642,12 @@ review:
     show if: minor_kids_with_respondent and current_possession_of_children == False and return_children_to == "court"
   - Edit: res_appear_alone
     button: |
-      **Should ${other_parties[0].name.full(middle="full")} be ordered to come to court alone?**
+      **Should ${other_parties[0].name_full()} be ordered to come to court alone?**
       ${ word(yesno(res_appear_alone))}
     show if: minor_kids_with_respondent and (current_possession_of_children == True or ( current_possession_of_children == False and return_children_to != "court" ))
   - Edit: res_appear_alone
     button: |
-      **Why should ${other_parties[0].name.full(middle="full")} be ordered to come to court alone?**
+      **Why should ${other_parties[0].name_full()} be ordered to come to court alone?**
       
       % if appear_alone_prevent:
       * To prevent abuse, neglect, removal, or concealment of the children
@@ -2656,7 +2656,7 @@ review:
       * To return the children to me
       % endif
       % if appear_alone_exam:
-      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name.full(middle="full")}
+      * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name_full()}
       % endif
       % if not appear_alone_prevent and not appear_alone_return and not appear_alone_exam:
       * No reasons entered
@@ -2664,10 +2664,10 @@ review:
     show if: minor_kids_with_respondent and (current_possession_of_children == True or ( current_possession_of_children == False and return_children_to != "court" )) and res_appear_alone
   - Edit: no_records_no_contact
     button: |
-      **${other_parties[0].name.full(middle="full")} should not have access to the children's records for the following reasons:**
+      **${other_parties[0].name_full()} should not have access to the children's records for the following reasons:**
       
       % if no_records_no_contact:
-      * I am requesting ${other_parties[0].name.full(middle="full")} have no contact with the children.
+      * I am requesting ${other_parties[0].name_full()} have no contact with the children.
       % endif
       % if no_records_hide_address:
       * My address is not listed on the court forms to prevent further abuse.
@@ -2682,23 +2682,23 @@ review:
     button: |
       **What should the court do about parenting time?**
       % if parenting_time == "deny":
-      Deny ${other_parties[0].name.full(middle="full")} any parenting time
+      Deny ${other_parties[0].name_full()} any parenting time
       % endif 
       % if parenting_time == "restrict":
-      Restrict ${other_parties[0].name.full(middle="full")}'s parenting time
+      Restrict ${other_parties[0].name_full()}'s parenting time
       % endif 
       % if parenting_time == "grant":
-      Grant or allow ${other_parties[0].name.full(middle="full")} parenting time
+      Grant or allow ${other_parties[0].name_full()} parenting time
       % endif 
       % if parenting_time == "reserve":
-      Reserve ${other_parties[0].name.full(middle="full")}'s parenting time until a later hearing
+      Reserve ${other_parties[0].name_full()}'s parenting time until a later hearing
       % endif 
   - Edit: restrict_or_deny_pt_reasons
     button: |
       % if parenting_time == "restrict":
-      **Why do you want to restrict ${other_parties[0].name.full(middle="full")}'s parenting time?**
+      **Why do you want to restrict ${other_parties[0].name_full()}'s parenting time?**
       % else:
-      **Why do you want to deny ${other_parties[0].name.full(middle="full")} any parenting time?**
+      **Why do you want to deny ${other_parties[0].name_full()} any parenting time?**
       % endif  
       
       % if restrict_or_deny_pt_reasons["no_pt_no_abuse"]:
@@ -2726,7 +2726,7 @@ review:
     show if: parenting_time == "restrict" or parenting_time == "grant"
   - Edit: pt_weekdays
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to have parenting time on weekdays?**
+      **Do you want ${other_parties[0].name_full()} to have parenting time on weekdays?**
       ${ word(yesno(pt_weekdays)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_format == "interview"
   - Edit: pt_weekday_days
@@ -2741,7 +2741,7 @@ review:
     
   - Edit: pt_weekends
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to have parenting time on weekends?**
+      **Do you want ${other_parties[0].name_full()} to have parenting time on weekends?**
       ${ word(yesno(pt_weekends)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_format == "interview"
   - Edit: pt_weekend_cadence
@@ -2771,7 +2771,7 @@ review:
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_format == "interview"
   - Edit: pt_supervised
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")}'s parenting time to be supervised?**
+      **Do you want ${other_parties[0].name_full()}'s parenting time to be supervised?**
       ${ word(yesno(pt_supervised)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant")
   - Edit: pt_supervisor_type
@@ -2786,7 +2786,7 @@ review:
   - Edit: pt_supervisor.name.first
     button: |
       **Adult who will supervise parenting time:**
-      ${ pt_supervisor.name.full(middle="full") }
+      ${ pt_supervisor.name_full() }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_supervised == True and pt_supervisor_type == "person"
   - Edit: pt_visitation_center_name
     button: |
@@ -2799,7 +2799,7 @@ review:
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_supervised == True and pt_supervisor_type == "agency"
   - Edit: pt_location_identified
     button: |
-      **Do you know where you want ${other_parties[0].name.full(middle="full")}'s parenting time to happen?**
+      **Do you know where you want ${other_parties[0].name_full()}'s parenting time to happen?**
       ${ word(yesno(pt_location_identified)) }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and ((pt_supervised and pt_supervisor_type == "person") or not pt_supervised)
   - Edit: pt_location_identified
@@ -2813,7 +2813,7 @@ review:
       % if pt_transportation == "petitioner":
       I will provide transportation.
       % elif pt_transportation == "respondent":
-      ${other_parties[0].name.full(middle="full")} will provide transportation.
+      ${other_parties[0].name_full()} will provide transportation.
       % elif pt_transportation == "other":
       Someone else will provide transportation.
       % else:
@@ -2823,7 +2823,7 @@ review:
   - Edit: pt_transportation_person.name.first
     button: |
       **Person who will provide transportation to and from parenting time:**
-      ${ pt_transportation_person.name.full(middle="full") }
+      ${ pt_transportation_person.name_full() }
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_transportation == "other"
   - Edit: pt_separate_pickup_location
     button: |
@@ -2855,7 +2855,7 @@ review:
     show if: (parenting_time == "restrict" or parenting_time == "grant") and pt_separate_return_location == True
   - Edit: pt_immediate_return
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to return the children immediately after parenting time?**
+      **Do you want ${other_parties[0].name_full()} to return the children immediately after parenting time?**
       ${ word(yesno(pt_immediate_return)) }
       % if pt_immediate_return:
       % if pt_return_person_choice == "Me":
@@ -2863,7 +2863,7 @@ review:
       They should be returned to me.
       % elif pt_return_person_choice == "other":
       
-      They should be returned to ${ pt_return_person.name.full(middle="full")}.
+      They should be returned to ${ pt_return_person.name_full()}.
       % else:
       
       I will identify a return person later.
@@ -2896,7 +2896,7 @@ review:
    
   - Edit: petitioner_personal_property.revisit
     button: |
-      **Personal property ${other_parties[0].name.full(middle="full")} should return to you:**
+      **Personal property ${other_parties[0].name_full()} should return to you:**
 
       % for my_var in petitioner_personal_property:
       % if my_var.respo_has == True:
@@ -2906,22 +2906,22 @@ review:
     show if: award_personal_property == True and return_property == True
   - Edit: return_property_reason
     button: |
-      **Why should ${other_parties[0].name.full(middle="full")} return the property?**
+      **Why should ${other_parties[0].name_full()} return the property?**
       % if return_property_reason == "petitioner owns":
       I own the property.
       % elif return_property_reason == "both own":      
       We both own the property, but sharing it would be harder on me. It would put me at risk for abuse or sharing is not practical.
       % else:
-      I am married to ${other_parties[0].name.full(middle="full")}, and we filed a divorce.
+      I am married to ${other_parties[0].name_full()}, and we filed a divorce.
       % endif
     show if: award_personal_property == True and return_property == True
   - Edit: return_property_person
     button: |
-      **Who should ${other_parties[0].name.full(middle="full")} return your property to?**
+      **Who should ${other_parties[0].name_full()} return your property to?**
       % if return_property_person == "petitioner":
       Me
       % else:
-      ${ other_return_property_person.name.full(middle="full") }
+      ${ other_return_property_person.name_full() }
       % endif
     show if: (award_personal_property == True and return_property == True)   
   - Edit: property_transfer_location_cb
@@ -2949,7 +2949,7 @@ review:
       Law enforcement, ${ property_transfer_police }
       % endif
       % else:
-      ${ other_transfer_property_person.name.full(middle="full") }
+      ${ other_transfer_property_person.name_full() }
       % endif
     show if: award_personal_property == True and return_property == True and property_transfer_location_cb == True and property_transfer_present_cb == True
   - Edit: property_transfer_know_date
@@ -2965,11 +2965,11 @@ review:
 
   - Edit: return_respo_property
     button: |
-      **Any personal property ${other_parties[0].name.full(middle="full")} will need returned to them right away?**
+      **Any personal property ${other_parties[0].name_full()} will need returned to them right away?**
       ${ word(yesno(return_respo_property)) }
   - Edit: respo_property
     button: |
-      **Personal property of ${other_parties[0].name.full(middle="full")} that should be returned:**
+      **Personal property of ${other_parties[0].name_full()} that should be returned:**
 
       % if respo_property['clothes'] == True:
       * Clothes
@@ -2983,12 +2983,12 @@ review:
     show if: (return_respo_property == True)
   - Edit: respo_property_other
     button: |
-      **Other personal property of ${other_parties[0].name.full(middle="full")}:**
+      **Other personal property of ${other_parties[0].name_full()}:**
       ${ respo_property_other }
     show if: (return_respo_property == True and respo_property['other'] == True)
   - Edit: respondent_one_time_entry
     button: |
-      **Should ${other_parties[0].name.full(middle="full")} be allowed to enter the home only one time to get their personal property?**
+      **Should ${other_parties[0].name_full()} be allowed to enter the home only one time to get their personal property?**
       ${ word(yesno(respondent_one_time_entry)) }
   - Edit: res_property_transfer_person
     button: |
@@ -3000,7 +3000,7 @@ review:
       Law enforcement, ${ res_property_transfer_police }
       % endif
       % else:
-      ${ res_other_transfer_property_person.name.full(middle="full") }
+      ${ res_other_transfer_property_person.name_full() }
       % endif
     show if: respondent_one_time_entry == True
     
@@ -3050,13 +3050,13 @@ review:
       % elif restrict_property_reason == "both":      
       We both own the property, but not having it would be harder on me. It would put me at risk for abuse or sharing is not practical.
       % else:
-      I am married to ${other_parties[0].name.full(middle="full")}, and we have filed for divorce.
+      I am married to ${other_parties[0].name_full()}, and we have filed for divorce.
       % endif
     show if: restrict_other_property == True
     
   - Edit: restrict_elderly_petitioner_resources
     button: |
-      **Should the court protect an elderly person's resources from  ${other_parties[0].name.full(middle="full")}?**
+      **Should the court protect an elderly person's resources from  ${other_parties[0].name_full()}?**
       % if restrict_elderly_petitioner_resources == "Yes":
       Yes
       % elif restrict_elderly_petitioner_resources == "No":
@@ -3076,12 +3076,12 @@ subquestion: |
 review:
   - Edit: temp_child_support
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to pay temporary child support?**
+      **Do you want ${other_parties[0].name_full()} to pay temporary child support?**
       ${ word(yesno(temp_child_support)) }
     show if: minor_kids_with_respondent == True
   - Edit: temp_maintenance
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to pay temporary maintenance?**
+      **Do you want ${other_parties[0].name_full()} to pay temporary maintenance?**
       ${ word(yesno(temp_maintenance)) }
     show if: relationship_se == True or relationship_xs == True
   - Edit: separate_phone_service
@@ -3092,9 +3092,9 @@ review:
     button: |
       **Who is the cell phone account holder?**
       % if phone_account_holder == 'respondent':
-      ${other_parties[0].name.full(middle="full")}
+      ${other_parties[0].name_full()}
       % else:
-      ${ other_phone_account_holder.name.full(middle="full") }
+      ${ other_phone_account_holder.name_full() }
       % endif
     show if: separate_phone_service == True
   - Edit: phone_provider
@@ -3102,7 +3102,7 @@ review:
       **Cell phone account details:**
       
       * Provider: ${ phone_provider }
-      * ${other_parties[0].name.full(middle="full")}'s phone number: ${ phone_number_formatted(billing_phone_number) }
+      * ${other_parties[0].name_full()}'s phone number: ${ phone_number_formatted(billing_phone_number) }
     show if: separate_phone_service == True
   - Edit: cell_numbers.revisit
     button: |
@@ -3114,7 +3114,7 @@ review:
     show if: separate_phone_service == True
   - Edit: expenses_none
     button: |
-      **Losses you want ${other_parties[0].name.full(middle="full")} to pay for:**
+      **Losses you want ${other_parties[0].name_full()} to pay for:**
 
       % if expenses_none:
       * None
@@ -3149,11 +3149,11 @@ review:
       % endif
   - Edit: request_counseling
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")} to get counseling?**
+      **Do you want ${other_parties[0].name_full()} to get counseling?**
       ${ word(yesno(request_counseling)) }
   - Edit: dv_counseling
     button: |
-      **Counseling you want ${ other_parties[0].name.full(middle="full") } to do:**
+      **Counseling you want ${ other_parties[0].name_full() } to do:**
       
       % if dv_counseling:
       * Domestic violence partner abuse counseling
@@ -3175,22 +3175,22 @@ review:
 
   - Edit: firearms_threat
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} a threat to the physical safety of you or your children?**
+      **Is ${other_parties[0].name_full()} a threat to the physical safety of you or your children?**
       ${ word(yesno(firearms_threat)) }
   - Edit: firearms_relief
     button: |
       **Do you want the court to order any firearms relief?**
 
       % if firearms_relief['surrender']:
-      * I want ${other_parties[0].name.full(middle="full")} to **surrender firearms** to law enforcement.
+      * I want ${other_parties[0].name_full()} to **surrender firearms** to law enforcement.
       % endif
       % if firearms_relief['warrant']:
-      * I want a **search warrant** to be issued so law enforcement can search ${other_parties[0].name.full(middle="full")}'s property and seize fierarms.
+      * I want a **search warrant** to be issued so law enforcement can search ${other_parties[0].name_full()}'s property and seize fierarms.
       % endif
     show if: firearms_threat
   - Edit: intimate_partner
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} a current or former intimate partner?**
+      **Is ${other_parties[0].name_full()} a current or former intimate partner?**
       % if intimate_partner == "Yes":
       Yes
       % elif intimate_partner == "No":
@@ -3204,13 +3204,13 @@ review:
       **Why do you want the court to order a search warrant?**
 
       % if warrant_reasons['threat']:
-      * ${other_parties[0].name.full(middle="full")} is an immediate threat to the physical safety of the people I want to protect.
+      * ${other_parties[0].name_full()} is an immediate threat to the physical safety of the people I want to protect.
       % endif
       % if warrant_reasons['has_guns']:
-      * ${other_parties[0].name.full(middle="full")} has a firearm or firearm parts that could be used to make a firearm.
+      * ${other_parties[0].name_full()} has a firearm or firearm parts that could be used to make a firearm.
       % endif
       % if warrant_reasons['location']:
-      * The firearm or firearm parts are in the residence, vehicle, or other property of ${other_parties[0].name.full(middle="full")}.
+      * The firearm or firearm parts are in the residence, vehicle, or other property of ${other_parties[0].name_full()}.
       % endif
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: warrant_location_list.revisit
@@ -3223,7 +3223,7 @@ review:
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: has_helpful_warrant_info
     button: |
-      **Do you have other information about ${other_parties[0].name.full(middle="full")} that could help law enforcement with the warrant?**
+      **Do you have other information about ${other_parties[0].name_full()} that could help law enforcement with the warrant?**
       ${ word(yesno(has_helpful_warrant_info))}      
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: has_helpful_warrant_info
@@ -3238,13 +3238,13 @@ review:
     show if: firearms_threat and firearms_relief['warrant']
   - Edit: firearms_eop_notice
     button: |
-      **Are you worried that ${other_parties[0].name.full(middle="full")} might hurt you or the people you want to protect when they learn about the Order of Protection?**
+      **Are you worried that ${other_parties[0].name_full()} might hurt you or the people you want to protect when they learn about the Order of Protection?**
       ${ word(yesno(firearms_eop_notice))}
     show if: firearms_threat and firearms_relief['surrender'] or firearms_relief['warrant']
   
   - Edit: misc_remedies_text
     button: |
-      **What else do you want the court to order ${other_parties[0].name.full(middle="full")} to do or to stop doing?**
+      **What else do you want the court to order ${other_parties[0].name_full()} to do or to stop doing?**
       % if misc_remedies_text == "":
       Nothing
       % else:
@@ -3267,7 +3267,7 @@ subquestion: |
 review:
   - Edit: knows_respondent_dob
     button: |
-      **What you know about ${other_parties[0].name.full(middle="full")}'s birthdate?**[NEWLINE]
+      **What you know about ${other_parties[0].name_full()}'s birthdate?**[NEWLINE]
       % if knows_respondent_dob == "exact" and other_parties[0].birthdate != "":
       The exact date: ${ other_parties[0].birthdate }
       % elif knows_respondent_dob == "some":
@@ -3277,7 +3277,7 @@ review:
       % endif
   - Edit: respondent_parent_help
     button: |
-      **Do you want ${other_parties[0].name.full(middle="full")}'s parent or guardian help them follow the Order of Protection?**
+      **Do you want ${other_parties[0].name_full()}'s parent or guardian help them follow the Order of Protection?**
       % if respondent_parent_help == "Yes":
       Yes
       % elif respondent_parent_help == "No":
@@ -3292,13 +3292,13 @@ review:
     show if: respondent_parent_help == "Yes"
   - Edit: respondent_parent_order
     button: |
-      **What should ${other_parties[0].name.full(middle="full")}'s parent or guardian be ordered to do?**
+      **What should ${other_parties[0].name_full()}'s parent or guardian be ordered to do?**
       ${ respondent_parent_order }
     show if: respondent_parent_help == "Yes"
 
   - Edit: other_parties[0].gender
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s gender?**
+      **What is ${other_parties[0].name_full()}'s gender?**
       % if other_parties[0].gender == "":
       None entered
       % endif
@@ -3313,7 +3313,7 @@ review:
       % endif
   - Edit: other_parties[0].gender_cook
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s gender identity (confidential)?**
+      **What is ${other_parties[0].name_full()}'s gender identity (confidential)?**
       
       % if other_parties[0].gender_cook.all_false():
       * None entered
@@ -3343,7 +3343,7 @@ review:
     show if: trial_court_index == -1
   - Edit: respondent_sex_at_birth
     button: |
-      **${other_parties[0].name.full(middle="full")}'s sex assigned at birth (condfidential):**
+      **${other_parties[0].name_full()}'s sex assigned at birth (condfidential):**
       % if respondent_sex_at_birth == "None":
       None entered
       % else:
@@ -3357,7 +3357,7 @@ review:
     
   - Edit: other_parties[0].race
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s race?**
+      **What is ${other_parties[0].name_full()}'s race?**
       % if other_parties[0].race == 'other':
       ${ respondent_race_other }
       % else:
@@ -3366,7 +3366,7 @@ review:
 
   - Edit: other_parties[0].height_feet
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s height?**
+      **What is ${other_parties[0].name_full()}'s height?**
       % if other_parties[0].height_feet > 1:
       ${ other_parties[0].height_feet } feet
       % if other_parties[0].height_inches > 0:
@@ -3377,7 +3377,7 @@ review:
       % endif
   - Edit: other_parties[0].weight
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s weight?**
+      **What is ${other_parties[0].name_full()}'s weight?**
       % if other_parties[0].weight > 0:
       ${ other_parties[0].weight } pounds
       % else:
@@ -3385,7 +3385,7 @@ review:
       % endif
   - Edit: other_parties[0].skin
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s skin color?**
+      **What is ${other_parties[0].name_full()}'s skin color?**
       % if other_parties[0].skin == 'other':
       ${ respondent_skin_other }
       % else:
@@ -3394,7 +3394,7 @@ review:
     show if: trial_court_index == -1
   - Edit: other_parties[0].hair
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s hair color?**
+      **What is ${other_parties[0].name_full()}'s hair color?**
       % if other_parties[0].hair != "":
       ${ other_parties[0].hair }
       % else:
@@ -3402,7 +3402,7 @@ review:
       % endif
   - Edit: other_parties[0].eyes
     button: |
-      **What is ${other_parties[0].name.full(middle="full")}'s eye color?**
+      **What is ${other_parties[0].name_full()}'s eye color?**
       % if other_parties[0].eyes != "":
       ${ other_parties[0].eyes }
       % else:
@@ -3410,7 +3410,7 @@ review:
       % endif
   - Edit: other_parties[0].tattoos
     button: |
-      **Other things about ${other_parties[0].name.full(middle="full")}'s appearance:**
+      **Other things about ${other_parties[0].name_full()}'s appearance:**
       % if other_parties[0].tattoos != "":
       ${ other_parties[0].tattoos }
       % else:
@@ -3418,7 +3418,7 @@ review:
       % endif
   - Edit: other_parties[0].glasses
     button: |
-      **Does ${other_parties[0].name.full(middle="full")} wear glasses?**
+      **Does ${other_parties[0].name_full()} wear glasses?**
       % if other_parties[0].glasses is not None:
       ${ other_parties[0].glasses }
       % else:
@@ -3428,12 +3428,12 @@ review:
       
   - Edit: other_parties[0].alias_names
     button: |
-      **Other names ${other_parties[0].name.full(middle="full")} has used:**
+      **Other names ${other_parties[0].name_full()} has used:**
       ${ other_parties[0].alias_names }
     show if: trial_court_index == -1
   - Edit: respondent_on_probation
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} on court-ordered probation?**
+      **Is ${other_parties[0].name_full()} on court-ordered probation?**
       % if respondent_on_probation == "Yes":
       Yes
       % elif respondent_on_probation == "No":
@@ -3449,7 +3449,7 @@ review:
     show if: respondent_on_probation == "Yes" and trial_court_index == -1
   - Edit: caution_reasons
     button : |
-      **Reasons sheriff should use caution when approaching ${other_parties[0].name.full(middle="full")}:**
+      **Reasons sheriff should use caution when approaching ${other_parties[0].name_full()}:**
       
       % if not any(caution_reasons):
       * None entered
@@ -3482,15 +3482,15 @@ review:
       
   - Edit: knows_respondent_home
     button: |
-      **Do you know ${other_parties[0].name.full(middle="full")}'s current home address?**
+      **Do you know ${other_parties[0].name_full()}'s current home address?**
       ${ word(yesno(knows_respondent_home)) }
   - Edit: knows_respondent_home_last
     button: |
-      **Do you know ${other_parties[0].name.full(middle="full")}'s last known address?**
+      **Do you know ${other_parties[0].name_full()}'s last known address?**
       ${ word(yesno(knows_respondent_home_last)) }      
   - Edit: other_parties[0].address.address
     button: |
-      **${other_parties[0].name.full(middle="full")}'s home address:**
+      **${other_parties[0].name_full()}'s home address:**
       % if other_parties[0].address.address != "":
       % if knows_respondent_home:
       ${ other_parties[0].address.on_one_line(bare=True) }
@@ -3502,7 +3502,7 @@ review:
       % endif
   - Edit: other_parties[0].phone_number
     button: |
-      **${other_parties[0].name.full(middle="full")}'s home phone number:**
+      **${other_parties[0].name_full()}'s home phone number:**
       % if other_parties[0].phone_number != "":
       ${ phone_number_formatted(other_parties[0].phone_number) }      
       % else:
@@ -3510,7 +3510,7 @@ review:
       % endif
   - Edit: other_parties[0].mobile_number
     button: |
-      **${other_parties[0].name.full(middle="full")}'s cell number:**
+      **${other_parties[0].name_full()}'s cell number:**
       % if other_parties[0].mobile_number != "":
       ${ phone_number_formatted(other_parties[0].mobile_number) }      
       % else:
@@ -3518,7 +3518,7 @@ review:
       % endif
   - Edit: other_parties[0].email
     button: |
-      **${other_parties[0].name.full(middle="full")}'s email:**
+      **${other_parties[0].name_full()}'s email:**
       % if other_parties[0].email != "":
       ${ other_parties[0].email }
       % else:
@@ -3526,20 +3526,20 @@ review:
       % endif
   - Edit: respondent_on_social_media
     button: |
-      **Is ${other_parties[0].name.full(middle="full")} active on social media?**
+      **Is ${other_parties[0].name_full()} active on social media?**
       ${ respondent_on_social_media }      
   - Edit: respondent_social_media_accounts
     button: |
-      **${other_parties[0].name.full(middle="full")}'s social media accounts:**
+      **${other_parties[0].name_full()}'s social media accounts:**
       ${ respondent_social_media_accounts }
     show if: respondent_on_social_media == 'Yes'
   - Edit: knows_respondent_work
     button: |
-      **Do you know ${other_parties[0].name.full(middle="full")}'s work info?**
+      **Do you know ${other_parties[0].name_full()}'s work info?**
       ${ word(yesno(knows_respondent_work)) }
   - Edit: other_parties[0].work_address.address
     button: |
-      **${other_parties[0].name.full(middle="full")}'s work info:**
+      **${other_parties[0].name_full()}'s work info:**
       % if knows_respondent_work:
       ${ other_parties[0].employer + ", " + other_parties[0].work_address.on_one_line(bare=True) }
       % else:
@@ -3547,7 +3547,7 @@ review:
       % endif
   - Edit: respondent_work_type
     button: |
-      **${other_parties[0].name.full(middle="full")}'s occupation or type of work:**
+      **${other_parties[0].name_full()}'s occupation or type of work:**
       % if knows_respondent_work and respondent_work_type != "":
       ${ respondent_work_type }
       % else:
@@ -3557,7 +3557,7 @@ review:
 
   - Edit: cook_vehicle_color
     button: |
-      **Details on ${other_parties[0].name.full(middle="full")}'s car:**
+      **Details on ${other_parties[0].name_full()}'s car:**
 
       % if respondent_car_make == "":
       * Car make: None entered
@@ -3594,7 +3594,7 @@ review:
 
   - Edit: other_parties[0].work_hours
     button: |
-      **${other_parties[0].name.full(middle="full")}'s work schedule:**
+      **${other_parties[0].name_full()}'s work schedule:**
       % if knows_respondent_work and other_parties[0].work_hours != "":
       ${ other_parties[0].work_hours }
       % else:
@@ -3603,12 +3603,12 @@ review:
 
   - Edit: has_other_ops
     button: |
-      **Are there other Orders of Protection against ${other_parties[0].name.full(middle="full")}?**
+      **Are there other Orders of Protection against ${other_parties[0].name_full()}?**
       ${ has_other_ops }
       
   - Edit: other_ops.revisit
     button: |
-      **Other Orders of Protection against ${other_parties[0].name.full(middle="full")}: (Edit to change details)**
+      **Other Orders of Protection against ${other_parties[0].name_full()}: (Edit to change details)**
 
       % for my_var in other_ops:
         * ${ my_var.name.text } in ${ my_var.year }
@@ -3617,12 +3617,12 @@ review:
 
   - Edit: has_other_cases
     button: |
-      **Are there other cases with ${other_parties[0].name.full(middle="full")}?**
+      **Are there other cases with ${other_parties[0].name_full()}?**
       ${ has_other_cases }
       
   - Edit: other_cases.revisit
     button: |
-      **Other cases with ${other_parties[0].name.full(middle="full")}: (Edit to change details)**
+      **Other cases with ${other_parties[0].name_full()}: (Edit to change details)**
 
       % for my_var in other_cases:
         * ${ my_var.name.text } in ${ my_var.year }
@@ -3640,7 +3640,7 @@ subquestion: |
 review:
   - Edit: service_method
     button: |
-      **How do you want ${other_parties[0].name.full(middle="full")} to be served?**
+      **How do you want ${other_parties[0].name_full()} to be served?**
       % if service_method == "sheriff":
       By the sheriff
       % elif service_method == "sps":
@@ -3653,7 +3653,7 @@ review:
 
   - Edit: service_address_choice
     button: |
-      **Where can ${other_parties[0].name.full(middle="full")} be found for service?**
+      **Where can ${other_parties[0].name_full()} be found for service?**
       % if service_address_choice == "other":
       At another address
       % else:
@@ -3666,11 +3666,11 @@ review:
     show if: service_address_choice == "other"
   - Edit: has_second_service_address
     button: |
-      **Do you know another location where ${other_parties[0].name.full(middle="full")} can be found for service?**
+      **Do you know another location where ${other_parties[0].name_full()} can be found for service?**
       ${ word(yesno(has_second_service_address)) }
   - Edit: second_service_address_choice
     button: |
-      **Where else can ${other_parties[0].name.full(middle="full")} be found for service?**
+      **Where else can ${other_parties[0].name_full()} be found for service?**
       % if second_service_address_choice == "other":
       At another address
       % else:
@@ -3684,23 +3684,23 @@ review:
     show if: has_second_service_address and second_service_address_choice == "other"
   - Edit: other_parties[0].phone_number_alt
     button: |
-      **${other_parties[0].name.full(middle="full")}'s other contact info:**
+      **${other_parties[0].name_full()}'s other contact info:**
   
       % if other_parties[0].phone_number_alt != "":
-      * ${other_parties[0].name.full(middle="full")}'s alternate phone: ${ phone_number_formatted(other_parties[0].phone_number_alt) }
+      * ${other_parties[0].name_full()}'s alternate phone: ${ phone_number_formatted(other_parties[0].phone_number_alt) }
       % else:
-      * ${other_parties[0].name.full(middle="full")}'s alternate phone: None entered
+      * ${other_parties[0].name_full()}'s alternate phone: None entered
       % endif
       % if other_parties[0].email_alt != "":
-      * ${other_parties[0].name.full(middle="full")}'s alternate email: ${ other_parties[0].email_alt }
+      * ${other_parties[0].name_full()}'s alternate email: ${ other_parties[0].email_alt }
       % else:
-      * ${other_parties[0].name.full(middle="full")}'s alternate email: None entered
+      * ${other_parties[0].name_full()}'s alternate email: None entered
       % endif
     show if: has_second_service_address
       
   - Edit: service_information
     button: |
-      **Additional information to help serve court papers on ${other_parties[0].name.full(middle="full")}:**
+      **Additional information to help serve court papers on ${other_parties[0].name_full()}:**
       ${ service_information }
     show if: trial_court_index == -1
 
@@ -3725,7 +3725,7 @@ review:
       % endif    
   - Edit: previous_cook_case_type
     button: |
-      **Previous Cook County case involving ${other_parties[0].name.full(middle="full")}:**
+      **Previous Cook County case involving ${other_parties[0].name_full()}:**
       ${ previous_cook_case_type.capitalize() }
     show if: trial_court_index == -1
   - Edit: previous_cook_case_date

--- a/docassemble/EmergencyOrderOfProtectionCookCounty/data/questions/order_of_protection.yml
+++ b/docassemble/EmergencyOrderOfProtectionCookCounty/data/questions/order_of_protection.yml
@@ -489,14 +489,14 @@ question: |
 subquestion: |
   email subject:
   % if preferred_contact == "phone":
-  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name.full(middle="full") } v. ${other_parties[0].name.full(middle="full")} - contact: ${ phone_number_formatted(safe_phone_number) }
+  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name_full() } v. ${other_parties[0].name_full()} - contact: ${ phone_number_formatted(safe_phone_number) }
   % else:
-  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name.full(middle="full") } v. ${other_parties[0].name.full(middle="full")} - contact: ${ safe_email }
+  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name_full() } v. ${other_parties[0].name_full()} - contact: ${ safe_email }
   % endif  
   
   [NEWLINE]
   Mail body: 
-  ${ users[0].name.full(middle="full") } is filing for a Petition for Order of Protection against ${other_parties[0].name.full(middle="full")}.
+  ${ users[0].name_full() } is filing for a Petition for Order of Protection against ${other_parties[0].name_full()}.
   
   Petitioner safe email address: ${ safe_email }
   
@@ -963,7 +963,7 @@ fields:
 ---
 id: know respondent birthdate
 question: |
-  Do you know ${other_parties[0].name.full(middle="full")}'s birthdate?
+  Do you know ${other_parties[0].name_full()}'s birthdate?
 fields:   
   - no label: knows_respondent_dob
     datatype: radio
@@ -977,13 +977,13 @@ fields:
           % else:
           You may want to update the sheriff's office when you have this information.
           % endif
-  - ${other_parties[0].name.full(middle="full")}'s date of birth: other_parties[0].birthdate
+  - ${other_parties[0].name_full()}'s date of birth: other_parties[0].birthdate
     datatype: ThreePartsDate
     alMax: ${ today().format("yyyy-MM-dd") }
     show if: 
       variable: knows_respondent_dob
       is: exact
-  - How old do you think ${other_parties[0].name.full(middle="full")} is?: other_parties[0].approx_age
+  - How old do you think ${other_parties[0].name_full()} is?: other_parties[0].approx_age
     maxlength: 20
     show if:
       variable: knows_respondent_dob
@@ -991,7 +991,7 @@ fields:
 ---
 id: minor kids with respondent
 question: |
-  Do you have any minor children with ${other_parties[0].name.full(middle="full")}?
+  Do you have any minor children with ${other_parties[0].name_full()}?
 subquestion:
   Minor children are under 18.
 field: minor_kids_with_respondent
@@ -1018,15 +1018,15 @@ fields:
   - Me: protect_petitioner
     datatype: yesnowide
     default: True
-  - Minor children I have with ${other_parties[0].name.full(middle="full")}: protect_shared_kids
+  - Minor children I have with ${other_parties[0].name_full()}: protect_shared_kids
     datatype: yesnowide
     help: |
-      Check this if you want the order to protect your minor children you have with ${other_parties[0].name.full(middle="full")}.
+      Check this if you want the order to protect your minor children you have with ${other_parties[0].name_full()}.
     # removing this show if to accommodate adding minor children thru review, maybe revisit
     #show if:
     #  code: |
     #    minor_kids_with_respondent == True
-  - My minor children I **did not** have with ${other_parties[0].name.full(middle="full")}: protect_petitioner_kids
+  - My minor children I **did not** have with ${other_parties[0].name_full()}: protect_petitioner_kids
     datatype: yesnowide
   - A dependent adult: protect_dependent_adult
     datatype: yesnowide
@@ -1053,7 +1053,7 @@ sets:
   - shared_kids[0].name.suffix
 id: name of first child with respondent
 question: |
-  Who is your minor child with ${other_parties[0].name.full(middle="full")}?
+  Who is your minor child with ${other_parties[0].name_full()}?
 subquestion: |
   The statewide Order of Protection forms have space for up to 6 minor children with the Respondent.
 fields:
@@ -1067,14 +1067,14 @@ sets:
   - shared_kids[i].name.last
   - shared_kids[i].name.suffix
 question: |
-  Who is your ${ ordinal(i) } minor child with ${other_parties[0].name.full(middle="full")}?
+  Who is your ${ ordinal(i) } minor child with ${other_parties[0].name_full()}?
 fields:
   - code: |
       shared_kids[i].name_fields()
 ---
 id: any other children with respondent
 question: |
-  Do you have another minor child with ${other_parties[0].name.full(middle="full")}?
+  Do you have another minor child with ${other_parties[0].name_full()}?
 subquestion: |
   The statewide Order of Protection forms have space for up to 6 minor children with the Respondent.
   % if len(shared_kids.elements) >= 1:  
@@ -1091,7 +1091,7 @@ sets:
   - petitioner_kids[0].name.suffix
 id: name of first child not with respondent
 question: |
-  Who is your minor child **not with** ${other_parties[0].name.full(middle="full")} you want protected by this order?
+  Who is your minor child **not with** ${other_parties[0].name_full()} you want protected by this order?
 subquestion: |
   If you want to include more than one, you can enter their names on following screens.
 fields:
@@ -1105,14 +1105,14 @@ sets:
   - petitioner_kids[i].name.last
   - petitioner_kids[i].name.suffix
 question: |
-  Who is your ${ ordinal(i) } minor child **not with** ${other_parties[0].name.full(middle="full")}  you want protected by this order?
+  Who is your ${ ordinal(i) } minor child **not with** ${other_parties[0].name_full()}  you want protected by this order?
 fields:
   - code: |
       petitioner_kids[i].name_fields()
 ---
 id: any other children not with respondent
 question: |
-  Do you have another minor child **not with** ${other_parties[0].name.full(middle="full")} you want protected by this order?
+  Do you have another minor child **not with** ${other_parties[0].name_full()} you want protected by this order?
 subquestion: |
   % if len(petitioner_kids.elements) >= 1:  
   So far you have told us about ${comma_and_list(petitioner_kids.complete_elements().full_names())}.
@@ -1161,7 +1161,7 @@ fields:
 id: minor child info
 generic object: ALIndividual
 question: |
-  Tell us more about ${ x.name.full(middle="full")}
+  Tell us more about ${ x.name_full()}
 subquestion: |
   ${ collapse_template(minor_child_residence_help) }
 fields:
@@ -1177,18 +1177,18 @@ fields:
       ${ collapse_template(legal_parentage_help) }
   - Your legal parentage has already been established.: x.pet_parentage
     datatype: yesnomaybe
-  - ${other_parties[0].name.full(middle="full")}'s legal parentage has already been established.: x.res_parentage
+  - ${other_parties[0].name_full()}'s legal parentage has already been established.: x.res_parentage
     datatype: yesnomaybe
   - Include as a protected person?: x.protect
     datatype: yesnoradio
     help: |
-      Select **Yes** if you want the order to protect the child from ${other_parties[0].name.full(middle="full")}. 
+      Select **Yes** if you want the order to protect the child from ${other_parties[0].name_full()}. 
 ---
 template: minor_child_residence_help
 subject: |
   **What if the child has not lived in the same state over the past 6 months?**
 content: |  
-  If ${ x.name.full(middle="full")} has not lived in Illinois or the state you select for the past 6 months, you may want to talk with a lawyer. There are laws that affect which state courts can settle things like child custody. If the child is under 6 months old, select where the child lived since birth.
+  If ${ x.name_full()} has not lived in Illinois or the state you select for the past 6 months, you may want to talk with a lawyer. There are laws that affect which state courts can settle things like child custody. If the child is under 6 months old, select where the child lived since birth.
   
   Call the [**Illinois Domestic Violence Hotline**](https://the-network.org/get-help/) at 877-863-6338 (877-TO END DV) to talk with an advocate. You can also use [**Get Legal Help**](https://www.illinoislegalaid.org/get-legal-help) to find free or low-cost legal services in your area.
 ---
@@ -1252,7 +1252,7 @@ fields:
 ---
 id: order type
 question: |
-  Which type of Order of Protection do you want against ${other_parties[0].name.full(middle="full")}?
+  Which type of Order of Protection do you want against ${other_parties[0].name_full()}?
 subquestion: |
   You can ask for both.
   
@@ -1264,17 +1264,17 @@ fields:
     help: |
       **Emergency Order of Protection**
 
-      * Judge can give this order on the same day you file, without notifying ${other_parties[0].name.full(middle="full")}
+      * Judge can give this order on the same day you file, without notifying ${other_parties[0].name_full()}
       * Lasts for 14 - 21 days
-      * After ${other_parties[0].name.full(middle="full")} is served with court papers, you can ask for a long-term (Plenary) Order of Protection
+      * After ${other_parties[0].name_full()} is served with court papers, you can ask for a long-term (Plenary) Order of Protection
   - Plenary: pop
     datatype: yesnowide
     help: |
       **Plenary (long-term) Order of Protection**
           
-      * Judge can give this order on a later date, after ${other_parties[0].name.full(middle="full")} has been notified
+      * Judge can give this order on a later date, after ${other_parties[0].name_full()} has been notified
       * Lasts for up to 2 years
-      * ${other_parties[0].name.full(middle="full")} will have a chance to participate in the court case
+      * ${other_parties[0].name_full()} will have a chance to participate in the court case
 validation code: |
   if not (eop or pop):
     validation_error("Please select at least one type of order to continue.", field="pop")
@@ -1284,7 +1284,7 @@ id: other ops
 question: |
   Other Orders of Protection
 subquestion: |
-  Is there now, or has there ever been, an Order of Protection in any state against ${other_parties[0].name.full(middle="full")} involving you or other people you want to protect in this Order?
+  Is there now, or has there ever been, an Order of Protection in any state against ${other_parties[0].name_full()} involving you or other people you want to protect in this Order?
 fields:
   - Other Orders of Protection?: has_other_ops
     datatype: radio
@@ -1358,9 +1358,9 @@ code: |
 
 id: other cases
 question: |
-  Other court cases with ${other_parties[0].name.full(middle="full")}
+  Other court cases with ${other_parties[0].name_full()}
 subquestion: |
-  Are there now, or have there ever been, any other court cases (civil or criminal) involving ${other_parties[0].name.full(middle="full")} and you or other people you want to protect in this Order?
+  Are there now, or have there ever been, any other court cases (civil or criminal) involving ${other_parties[0].name_full()} and you or other people you want to protect in this Order?
   
   Examples include:
   
@@ -1480,8 +1480,8 @@ question: |
 subquestion: |
   Try to be specific about:
   
-  * What ${other_parties[0].name.full(middle="full")} did,
-  * What ${other_parties[0].name.full(middle="full")} said,
+  * What ${other_parties[0].name_full()} did,
+  * What ${other_parties[0].name_full()} said,
   * Where the abuse happened,
   * How the abuse happened, such as in person, by phone or text, etc.,
   * Who was there when the abuse happened, and
@@ -1513,8 +1513,8 @@ question: |
 subquestion: |
   Try to be specific about:
   
-  * What ${other_parties[0].name.full(middle="full")} did,
-  * What ${other_parties[0].name.full(middle="full")} said,
+  * What ${other_parties[0].name_full()} did,
+  * What ${other_parties[0].name_full()} said,
   * Where the abuse happened,
   * How the abuse happened, such as in person, by phone or text, etc.,
   * Who was there when the abuse happened, and
@@ -1575,11 +1575,11 @@ code: |
 ---
 id: no abuse
 question: |
-  What do you want the court to order ${other_parties[0].name.full(middle="full")} to not do?
+  What do you want the court to order ${other_parties[0].name_full()} to not do?
 subquestion: |
-  This includes ordering ${other_parties[0].name.full(middle="full")} to not to threaten to do these things.
+  This includes ordering ${other_parties[0].name_full()} to not to threaten to do these things.
 
-  Check as many as you want, even if ${other_parties[0].name.full(middle="full")} has not done this before.
+  Check as many as you want, even if ${other_parties[0].name_full()} has not done this before.
 fields:
   - Harassment: no_harassment
     datatype: yesnowide
@@ -1662,9 +1662,9 @@ fields:
 ---
 id: stay away
 question: |
-  Do you want the court to order ${other_parties[0].name.full(middle="full")} to stay away and not communicate with people protected by this order?
+  Do you want the court to order ${other_parties[0].name_full()} to stay away and not communicate with people protected by this order?
 subquestion: |
-  If ordered to stay away, ${other_parties[0].name.full(middle="full")} must not have any physical, non-physical, direct, or indirect contact with the people protected by this order. This includes:
+  If ordered to stay away, ${other_parties[0].name_full()} must not have any physical, non-physical, direct, or indirect contact with the people protected by this order. This includes:
   
   * Oral communication,
   * Written communication,
@@ -1678,14 +1678,14 @@ subquestion: |
   
   with people protected by this order. This also includes contact or communication through others who may not know about the Order of Protection.
 fields:
-  - ${other_parties[0].name.full(middle="full")} should stay away at all times and have no contact?: stay_away
+  - ${other_parties[0].name_full()} should stay away at all times and have no contact?: stay_away
     datatype: yesnoradio
 ---
 id: no stay under influence
 question: |
-  Do you want the court to order ${other_parties[0].name.full(middle="full")} to stay away from and not be at your residence while under the influence?
+  Do you want the court to order ${other_parties[0].name_full()} to stay away from and not be at your residence while under the influence?
 subquestion: |
-  Select **Yes** if when ${other_parties[0].name.full(middle="full")} is under the influence of drugs or alcohol, they are a threat to you or your children.
+  Select **Yes** if when ${other_parties[0].name_full()} is under the influence of drugs or alcohol, they are a threat to you or your children.
 fields:
   - No entry or presence while under the influence?: no_stay_under_influence
     datatype: yesnoradio
@@ -1753,8 +1753,8 @@ fields:
   - no label: residence_remedies
     datatype: radio
     choices:
-    - I want **exclusive possession** of the residence. This means ${other_parties[0].name.full(middle="full")} should not be allowed to enter or stay there.: exclusive possession
-    - I want ${other_parties[0].name.full(middle="full")} to **provide a different place** for me and the protected people to live because we share a residence.: provide alternate housing
+    - I want **exclusive possession** of the residence. This means ${other_parties[0].name_full()} should not be allowed to enter or stay there.: exclusive possession
+    - I want ${other_parties[0].name_full()} to **provide a different place** for me and the protected people to live because we share a residence.: provide alternate housing
     - None of the above: none
 
 ---
@@ -1763,13 +1763,13 @@ question: |
   Why should the court give you exclusive possession of your residence?
 field: exclusive_possession_reason
 choices:
-  - I have a right to occupy the residence and ${other_parties[0].name.full(middle="full")} has no right.: respondent_no_right_to_stay
+  - I have a right to occupy the residence and ${other_parties[0].name_full()} has no right.: respondent_no_right_to_stay
   - Both of us have a right to occupy the residence, but it would be harder on me or any of my children or dependents to leave.: both_parties_right_to_stay
 
 ---
 id: respondent info
 question: |
-  What are ${other_parties[0].name.full(middle="full")}'s phone number and email address?
+  What are ${other_parties[0].name_full()}'s phone number and email address?
 subquestion: |
   If you do not know, leave these blank.
 fields:
@@ -1785,13 +1785,13 @@ fields:
 ---
 id: respondent social media
 question: |
-  Is ${other_parties[0].name.full(middle="full")} active on social media?
+  Is ${other_parties[0].name_full()} active on social media?
 subquestion: |
-  If you know about ${other_parties[0].name.full(middle="full")}'s accounts, this could help the sheriff find them.
+  If you know about ${other_parties[0].name_full()}'s accounts, this could help the sheriff find them.
   
   This information **will not** appear on public court documents.
 fields:
-  - ${other_parties[0].name.full(middle="full")} active on social media?: respondent_on_social_media
+  - ${other_parties[0].name_full()} active on social media?: respondent_on_social_media
     datatype: radio
     choices:
       - Yes: Yes
@@ -1809,7 +1809,7 @@ fields:
 ---
 id: respondent home address question
 question: |
-  Do you know ${other_parties[0].name.full(middle="full")}'s current home address?
+  Do you know ${other_parties[0].name_full()}'s current home address?
 subquestion: |
   If you do not know the current address, select **No**. You can enter their last known address on another screen.
 fields:
@@ -1818,7 +1818,7 @@ fields:
 ---
 id: respondent last known address
 question: |
-  Do you know ${other_parties[0].name.full(middle="full")}'s last known address?
+  Do you know ${other_parties[0].name_full()}'s last known address?
 fields:
   - no label: knows_respondent_home_last
     datatype: yesnoradio
@@ -1826,9 +1826,9 @@ fields:
 id: respondent address
 question: |
   % if knows_respondent_home:
-  What is ${other_parties[0].name.full(middle="full")}'s current home address?
+  What is ${other_parties[0].name_full()}'s current home address?
   % else:
-  What is ${other_parties[0].name.full(middle="full")}'s last known address?
+  What is ${other_parties[0].name_full()}'s last known address?
   % endif
 fields:
   - Street address: other_parties[0].address.address
@@ -1844,16 +1844,16 @@ fields:
 ---
 id: respondent work question
 question: |
-  Do you know ${other_parties[0].name.full(middle="full")}'s work information?
+  Do you know ${other_parties[0].name_full()}'s work information?
 subquestions: |
-  If ${other_parties[0].name.full(middle="full")} is currently unemployed, you can select **No**.
+  If ${other_parties[0].name_full()} is currently unemployed, you can select **No**.
 fields:
-  - Know ${other_parties[0].name.full(middle="full")}'s work info?: knows_respondent_work
+  - Know ${other_parties[0].name_full()}'s work info?: knows_respondent_work
     datatype: yesnoradio
 ---
 id: respondent work info
 question: |
-  Tell us about ${other_parties[0].name.full(middle="full")}'s job
+  Tell us about ${other_parties[0].name_full()}'s job
 subquestion: |
 fields:
   - Employer or company: other_parties[0].employer
@@ -1882,7 +1882,7 @@ fields:
 ---
 id: stay away work question
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to stay away from where you work while you are there?
+  Do you want ${other_parties[0].name_full()} to stay away from where you work while you are there?
 subquestion: |
   The statewide Order of Protection forms have space for up to 2 places of employment.
   
@@ -1936,17 +1936,17 @@ fields:
 ---
 id: another stay away job
 question: |
-  Do you have another job you want ${other_parties[0].name.full(middle="full")} to stay away from while you are there?
+  Do you have another job you want ${other_parties[0].name_full()} to stay away from while you are there?
 fields:
   - no label: stay_away_jobs_2
     datatype: yesnoradio
 ---
 id: stay away school question
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to stay away from any schools, kindergartens, or daycare centers while you or people you want to protect are there?
+  Do you want ${other_parties[0].name_full()} to stay away from any schools, kindergartens, or daycare centers while you or people you want to protect are there?
 subquestion: |
   % if minor_kids_with_respondent or protect_petitioner_kids:
-  The statewide Order of Protection forms have space for up to 2 schools or daycares. If you need to list more than 2 schools or daycares, you can add them as "other places" you want ${other_parties[0].name.full(middle="full")} to stay away from.
+  The statewide Order of Protection forms have space for up to 2 schools or daycares. If you need to list more than 2 schools or daycares, you can add them as "other places" you want ${other_parties[0].name_full()} to stay away from.
   
   **Note:** You can keep the name and address of these schools confidential if your children attend them.
   % else:
@@ -1965,7 +1965,7 @@ question: |
   % endif
 subquestion: |  
   % if minor_kids_with_respondent or protect_petitioner_kids:
-  If you do not want this information on your court forms, which can be seen by ${ other_parties[0].name.full(middle="full") }, check **Yes** to the **Hide this information** question below.
+  If you do not want this information on your court forms, which can be seen by ${ other_parties[0].name_full() }, check **Yes** to the **Hide this information** question below.
   % endif
 fields:
   - School or daycare name: schools[i].name
@@ -1979,7 +1979,7 @@ fields:
     code: |
       states_list()
   - ZIP code: schools[i].zip
-  - Hide this information from ${ other_parties[0].name.full(middle="full") }?: schools[i].hide
+  - Hide this information from ${ other_parties[0].name_full() }?: schools[i].hide
     datatype: yesnoradio
     show if: 
       code: |
@@ -1989,14 +1989,14 @@ fields:
 ---
 id: second stay away school
 question: |
-  Do you have another school or daycare you want ${other_parties[0].name.full(middle="full")} to stay away from while you or people you want to protect are there?
+  Do you have another school or daycare you want ${other_parties[0].name_full()} to stay away from while you or people you want to protect are there?
 subquestion: |  
   So far you entered: ${ schools[0].name }
 
   % if minor_kids_with_respondent or protect_petitioner_kids:
-  **Note:** You can enter up to 2 schools or daycares that you want ${other_parties[0].name.full(middle="full")} to stay away from. If you need to list more than 2 schools or daycares, you can add them as "other places" you want ${other_parties[0].name.full(middle="full")} to stay away from.
+  **Note:** You can enter up to 2 schools or daycares that you want ${other_parties[0].name_full()} to stay away from. If you need to list more than 2 schools or daycares, you can add them as "other places" you want ${other_parties[0].name_full()} to stay away from.
   % else:
-  **Note:** You can enter up to 2 schools or daycares that you want ${other_parties[0].name.full(middle="full")} to stay away from.
+  **Note:** You can enter up to 2 schools or daycares that you want ${other_parties[0].name_full()} to stay away from.
   % endif
 fields:
   - no label: stay_away_schools_2
@@ -2014,11 +2014,11 @@ code: |
   if minor_kids_with_respondent:
     if shared_kids.number() > 0:
       for person in shared_kids:
-        minor_kids_list.append( {person.name.full(middle="full"): person.name.full(middle="full") } )
+        minor_kids_list.append( {person.name_full(): person.name_full() } )
   if protect_petitioner_kids:
     if petitioner_kids.number() > 0:
       for person in petitioner_kids:
-        minor_kids_list.append( {person.name.full(middle="full"): person.name.full(middle="full") } )
+        minor_kids_list.append( {person.name_full(): person.name_full() } )
 ---
 id: confidential school details
 question: |
@@ -2039,7 +2039,7 @@ fields:
 ---
 id: stay away other location question
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to stay away from other places while you are there?
+  Do you want ${other_parties[0].name_full()} to stay away from other places while you are there?
 subquestion: |
   The statewide Order of Protection forms have space for up to 2 other places.
   % if stay_away_schools:
@@ -2075,7 +2075,7 @@ choices:
 ---
 id: stay away other location name
 question: |
-  Tell us about the place you want ${other_parties[0].name.full(middle="full")} to stay away from
+  Tell us about the place you want ${other_parties[0].name_full()} to stay away from
 subquestion: |
   This description will appear on your court papers.
 fields:
@@ -2083,7 +2083,7 @@ fields:
 ---
 id: stay away other location 2 name
 question: |
-  Tell us about the second place you want ${other_parties[0].name.full(middle="full")} to stay away from
+  Tell us about the second place you want ${other_parties[0].name_full()} to stay away from
 subquestion: |
   This description will appear on your court papers.
 fields:
@@ -2093,9 +2093,9 @@ fields:
 id: stay away other location info
 question: |
   % if i==0:
-  Tell us about the place you want ${other_parties[0].name.full(middle="full")} to stay away from
+  Tell us about the place you want ${other_parties[0].name_full()} to stay away from
   % else:
-  Tell us about the second place you want ${other_parties[0].name.full(middle="full")} to stay away from
+  Tell us about the second place you want ${other_parties[0].name_full()} to stay away from
   % endif
 subquestion: |
   **This address will appear on your court papers.** If you do not want this, click **Back** to keep this address hidden.
@@ -2114,7 +2114,7 @@ fields:
 ---
 id: another stay away location
 question: |
-  Do you have another place you want ${other_parties[0].name.full(middle="full")} to stay away from while you are there?
+  Do you have another place you want ${other_parties[0].name_full()} to stay away from while you are there?
 subquestion: |
   % if other_location_1_is_school:
   So far you entered: ${ schools[2].name }
@@ -2132,25 +2132,25 @@ fields:
 ---
 id: attend same school
 question: |
-  Does ${other_parties[0].name.full(middle="full")} attend the same school as you or any of the people you want to protect?
+  Does ${other_parties[0].name_full()} attend the same school as you or any of the people you want to protect?
 fields:
   - no label: same_school
     datatype: yesnoradio
 ---
 id: school restrictions
 question: |
-  What should the court order ${other_parties[0].name.full(middle="full")} to do at the school?
+  What should the court order ${other_parties[0].name_full()} to do at the school?
 fields:
   - no label: same_school_restrictions
     datatype: radio
     choices:
-      - ${other_parties[0].name.full(middle="full")} should not attend the school while I or other protected people are enrolled there.: not attend
-      - ${other_parties[0].name.full(middle="full")} should change their placement or program at the school, as determined by the public school district or private school.: change program
-      - ${other_parties[0].name.full(middle="full")} should not be present in certain parts of the school.: not present in parts
+      - ${other_parties[0].name_full()} should not attend the school while I or other protected people are enrolled there.: not attend
+      - ${other_parties[0].name_full()} should change their placement or program at the school, as determined by the public school district or private school.: change program
+      - ${other_parties[0].name_full()} should not be present in certain parts of the school.: not present in parts
         help: |
-          If you select this, you can list the parts of the school where ${other_parties[0].name.full(middle="full")} should not go.
-      - I don't want the court to order any school restrictions on ${other_parties[0].name.full(middle="full")}.: none
-  - Parts of the school where ${other_parties[0].name.full(middle="full")} should not go: parts_of_school
+          If you select this, you can list the parts of the school where ${other_parties[0].name_full()} should not go.
+      - I don't want the court to order any school restrictions on ${other_parties[0].name_full()}.: none
+  - Parts of the school where ${other_parties[0].name_full()} should not go: parts_of_school
     input type: area
     rows: 3
     maxlength: 150  
@@ -2161,7 +2161,7 @@ fields:
 ---
 id: same school name
 question: |
-  What is the name of the school ${other_parties[0].name.full(middle="full")} attends?
+  What is the name of the school ${other_parties[0].name_full()} attends?
 subquestion: |
   This can be an elementary, middle, or high school. 
 fields:
@@ -2170,9 +2170,9 @@ fields:
 ---
 id: minor respondent parents help
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")}'s parent or guardian to help them follow the Order of Protection?
+  Do you want ${other_parties[0].name_full()}'s parent or guardian to help them follow the Order of Protection?
 subquestion: |
-  You can ask for this if you know or think ${other_parties[0].name.full(middle="full")} is under age 18.
+  You can ask for this if you know or think ${other_parties[0].name_full()} is under age 18.
 fields:
   - no label: respondent_parent_help
     datatype: radio
@@ -2183,12 +2183,12 @@ fields:
 ---
 id: minor respondent parent info
 question: |
-  Requirements for ${other_parties[0].name.full(middle="full")}'s parent or guardian
+  Requirements for ${other_parties[0].name_full()}'s parent or guardian
 fields:
   - Parent or guardian name: respondent_parent_name
     maxlength: 60
     required: False
-  - What should ${other_parties[0].name.full(middle="full")}'s parent or guardian be ordered to do?: respondent_parent_order
+  - What should ${other_parties[0].name_full()}'s parent or guardian be ordered to do?: respondent_parent_order
     input type: area
     rows: 6
     maxlength: 200
@@ -2196,9 +2196,9 @@ fields:
 ---
 id: request counseling for respondent
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to get counseling?
+  Do you want ${other_parties[0].name_full()} to get counseling?
 subquestion: |
-  The court can order evaluation and treatment only after ${other_parties[0].name.full(middle="full")} has received written notice or attended the court hearing where this is decided.
+  The court can order evaluation and treatment only after ${other_parties[0].name_full()} has received written notice or attended the court hearing where this is decided.
 
   ${ collapse_template(counseling_help) }  
 fields:
@@ -2218,9 +2218,9 @@ content: |
 ---
 id: counseling types
 question: |
-  What kinds of counseling do you want the court to order ${other_parties[0].name.full(middle="full")} to participate in and complete?
+  What kinds of counseling do you want the court to order ${other_parties[0].name_full()} to participate in and complete?
 subquestion: |
-  The court can order evaluation and treatment only after ${other_parties[0].name.full(middle="full")} has received **{advance written notice}** or attended the court hearing where this is decided.
+  The court can order evaluation and treatment only after ${other_parties[0].name_full()} has received **{advance written notice}** or attended the court hearing where this is decided.
   
   Check all that apply.
 fields:
@@ -2232,7 +2232,7 @@ fields:
     datatype: yesnowide
   - Other counseling: other_counseling
     datatype: yesnowide
-  - Other counseling ${other_parties[0].name.full(middle="full")} should complete: other_counseling_text
+  - Other counseling ${other_parties[0].name_full()} should complete: other_counseling_text
     input type: area
     rows: 2
     maxlength: 60
@@ -2252,17 +2252,17 @@ code: |
 ---
 id: want court to make decisions about children
 question: |
-  Do you want the court to make decisions about your minor children you have with ${ other_parties[0].name.full(middle="full") }?
+  Do you want the court to make decisions about your minor children you have with ${ other_parties[0].name_full() }?
 subquestion: |
   In the Order of Protection, the court can decide:
 
   * Who is responsible for the children,  
   * Who the children will stay with, and
-  * What kind of parenting time you want ${ other_parties[0].name.full(middle="full") } to have, if any.
+  * What kind of parenting time you want ${ other_parties[0].name_full() } to have, if any.
 
   % if protect_shared_kids or include_shared_kids:
 
-  **Note:** Earlier, you said you wanted to protect your minor children you have with ${ other_parties[0].name.full(middle="full") }. Select **Yes** to answer questions about what you want the court to do for them. If you did not mean to include them in the Order of Protection, click the **:edit: Edit answers** button below to change your answers.
+  **Note:** Earlier, you said you wanted to protect your minor children you have with ${ other_parties[0].name_full() }. Select **Yes** to answer questions about what you want the court to do for them. If you did not mean to include them in the Order of Protection, click the **:edit: Edit answers** button below to change your answers.
   % endif
 fields:
   - no label: court_make_children_decisions
@@ -2286,16 +2286,16 @@ fields:
 ---
 id: primary caretaker
 question: |
-  Who is the primary caretaker of the children with ${other_parties[0].name.full(middle="full")}?
+  Who is the primary caretaker of the children with ${other_parties[0].name_full()}?
 fields:
   - no label: primary_caretaker
     datatype: radio
     choices:
       - I am.: petitioner
-      - ${other_parties[0].name.full(middle="full")} is.: respondent
-      - Another person is the primary caretaker of the children with ${other_parties[0].name.full(middle="full")}.: other
+      - ${other_parties[0].name_full()} is.: respondent
+      - Another person is the primary caretaker of the children with ${other_parties[0].name_full()}.: other
   - note: |
-      Enter the name of the primary caretaker of the children with ${other_parties[0].name.full(middle="full")}. 
+      Enter the name of the primary caretaker of the children with ${other_parties[0].name_full()}. 
     show if:
       variable: primary_caretaker
       is: "other"
@@ -2323,9 +2323,9 @@ fields:
 ---
 id: other caretaker address
 question: | 
-  What is ${ other_caretaker.name.full(middle="full") }'s address?
+  What is ${ other_caretaker.name_full() }'s address?
 subquestion: |
-  **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name.full(middle="full")}.
+  **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name_full()}.
 fields:
   - Street address: other_caretaker.address.address
     address autocomplete: True
@@ -2339,14 +2339,14 @@ fields:
 ---
 id: temporary custody
 question: |
-  Do you want the court to grant you temporary decision-making responsibility of the children you have with ${other_parties[0].name.full(middle="full")}?
+  Do you want the court to grant you temporary decision-making responsibility of the children you have with ${other_parties[0].name_full()}?
 subquestion: |
   This used to be called "custody" in Illinois.
   
   Notes:
   
   * This is not the same as primary decision-making responsibility.
-  * The court can order this only after ${other_parties[0].name.full(middle="full")} received **{advance written notice}** or attended the court hearing where this is decided.
+  * The court can order this only after ${other_parties[0].name_full()} received **{advance written notice}** or attended the court hearing where this is decided.
 
 fields:
   - no label: temp_custody_of_children
@@ -2354,7 +2354,7 @@ fields:
 ---
 id: physical care and possession of children
 question: |
-  Do you want the court to grant you physical care and possession of the children you have with ${other_parties[0].name.full(middle="full")}?
+  Do you want the court to grant you physical care and possession of the children you have with ${other_parties[0].name_full()}?
 subquestion: |
   This means the children would live with you on a day-to-day basis.
 
@@ -2365,18 +2365,18 @@ fields:
 ---
 id: concealment of children
 question: |
-  Do you want the court to order that ${other_parties[0].name.full(middle="full")} cannot hide or remove the children from Illinois?
+  Do you want the court to order that ${other_parties[0].name_full()} cannot hide or remove the children from Illinois?
 subquestion: |
-  You may want this if ${other_parties[0].name.full(middle="full")} has made threats or attempts to unlawfully remove the children.
+  You may want this if ${other_parties[0].name_full()} has made threats or attempts to unlawfully remove the children.
 fields:
   - no label: no_conceal_children
     datatype: yesnoradio    
 ---
 id: no removal of children from petitioner or school
 question: |
-  Do you want the court to order that ${other_parties[0].name.full(middle="full")} cannot remove the children from your care or from a school or daycare?
+  Do you want the court to order that ${other_parties[0].name_full()} cannot remove the children from your care or from a school or daycare?
 subquestion: |
-  You can keep the name and location of the school or daycare hidden from ${other_parties[0].name.full(middle="full")}.
+  You can keep the name and location of the school or daycare hidden from ${other_parties[0].name_full()}.
 
   If you want to change confidential schools, edit information about schools in [**Protections**](${ url_action('section_protections') }) section.
 fields:
@@ -2385,32 +2385,32 @@ fields:
 ---
 id: have current possession of children
 question: |
-  Do you currently have physical care and possession of your children with  ${other_parties[0].name.full(middle="full")}?
+  Do you currently have physical care and possession of your children with  ${other_parties[0].name_full()}?
 subquestion: |
-  If the children are not with you now, the court can order ${other_parties[0].name.full(middle="full")} to return them to you, to another person, or to bring the children to court.
+  If the children are not with you now, the court can order ${other_parties[0].name_full()} to return them to you, to another person, or to bring the children to court.
 fields:
   - no label: current_possession_of_children
     datatype: yesnoradio
 ---
 id: know children return details
 question: |
-  Do you know where you want ${other_parties[0].name.full(middle="full")} to return the children to ${ return_children_other_person.name.full(middle="full") }?
+  Do you know where you want ${other_parties[0].name_full()} to return the children to ${ return_children_other_person.name_full() }?
 fields:
   - no label: knows_return_children_details
     datatype: yesnoradio
 ---
 id: children returned to whom
 question: |
-  Who should ${other_parties[0].name.full(middle="full")} return the children to?
+  Who should ${other_parties[0].name_full()} return the children to?
 fields:
   - no label: return_children_to
     datatype: radio
     choices:
-      - ${other_parties[0].name.full(middle="full")} should return the children to me.: petitioner
-      - ${other_parties[0].name.full(middle="full")} should return the children to someone else.: other
-      - ${other_parties[0].name.full(middle="full")} should bring the children to court. This is usually 14 to 21 days after you file your petition.: court
+      - ${other_parties[0].name_full()} should return the children to me.: petitioner
+      - ${other_parties[0].name_full()} should return the children to someone else.: other
+      - ${other_parties[0].name_full()} should bring the children to court. This is usually 14 to 21 days after you file your petition.: court
   - note: |
-      Enter the name of the person ${other_parties[0].name.full(middle="full")} should return the children to. 
+      Enter the name of the person ${other_parties[0].name_full()} should return the children to. 
     show if:
       variable: return_children_to
       is: "other"
@@ -2437,11 +2437,11 @@ fields:
 ---
 id: children return location
 question: |
-  Where should ${other_parties[0].name.full(middle="full")} return the children to?
+  Where should ${other_parties[0].name_full()} return the children to?
 subquestion: |
   On the next screen you can enter more information about when the children should be returned and if anyone else should be present.
   
-  **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name.full(middle="full")}.  
+  **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name_full()}.  
 fields:
   - Street address: return_children_location.address
     address autocomplete: True
@@ -2456,7 +2456,7 @@ fields:
 ---
 id: reason respondent should bring children to court
 question: |
-  Why should ${other_parties[0].name.full(middle="full")} be ordered to bring the children to court?
+  Why should ${other_parties[0].name_full()} be ordered to bring the children to court?
 subquestion: |
   Check all that apply.
 fields:
@@ -2464,23 +2464,23 @@ fields:
     datatype: yesnowide
   - To return the children to you: appear_with_children_return
     datatype: yesnowide
-  - To permit a court-ordered interview or examination of the children or of ${other_parties[0].name.full(middle="full")}: appear_with_children_exam
+  - To permit a court-ordered interview or examination of the children or of ${other_parties[0].name_full()}: appear_with_children_exam
     datatype: yesnowide
 ---
 id: order respondent to appear in court
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} be ordered to come to court alone?
+  Do you want ${other_parties[0].name_full()} be ordered to come to court alone?
 subquestion: |
   You can ask for this 
 
   * To prevent abuse, neglect, removal, or concealment of the children,
   * To return the children to you, or
-  * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name.full(middle="full")}.  
+  * To permit a court-ordered interview or examination of the children or of ${other_parties[0].name_full()}.  
 fields:
-  - Should ${other_parties[0].name.full(middle="full")} be ordered to come to court alone?: res_appear_alone
+  - Should ${other_parties[0].name_full()} be ordered to come to court alone?: res_appear_alone
     datatype: yesnoradio
   - note: |
-      Why should ${other_parties[0].name.full(middle="full")} be ordered to come to court alone?
+      Why should ${other_parties[0].name_full()} be ordered to come to court alone?
       
       Check all that apply.
     show if: res_appear_alone
@@ -2490,21 +2490,21 @@ fields:
   - To return the children to you: appear_alone_return
     datatype: yesnowide
     show if: res_appear_alone
-  - To permit a court-ordered interview or examination of the children or of ${other_parties[0].name.full(middle="full")}: appear_alone_exam
+  - To permit a court-ordered interview or examination of the children or of ${other_parties[0].name_full()}: appear_alone_exam
     datatype: yesnowide
     show if: res_appear_alone
 ---
 id: childrens records
 question: |
-  Do you want the court to prevent ${other_parties[0].name.full(middle="full")} from accessing your children's records?
+  Do you want the court to prevent ${other_parties[0].name_full()} from accessing your children's records?
 subquestion: |
-  These include school records, health care records, or any other records. The records may have address and contact information you want to keep hidden from ${other_parties[0].name.full(middle="full")}.
+  These include school records, health care records, or any other records. The records may have address and contact information you want to keep hidden from ${other_parties[0].name_full()}.
 
-  If you want to deny ${other_parties[0].name.full(middle="full")} accessing to your children's records, select the reasons why. Check all that apply.
+  If you want to deny ${other_parties[0].name_full()} accessing to your children's records, select the reasons why. Check all that apply.
 fields:
-  - Yes. I am requesting that ${other_parties[0].name.full(middle="full")} not be allowed to have contact with the minor children.: no_records_no_contact
+  - Yes. I am requesting that ${other_parties[0].name_full()} not be allowed to have contact with the minor children.: no_records_no_contact
     help: |
-      Select this if you asked the court to prevent ${other_parties[0].name.full(middle="full")} from having any contact with the children.
+      Select this if you asked the court to prevent ${other_parties[0].name_full()} from having any contact with the children.
     datatype: yesnowide
   - Yes. My address is not included on the court forms to avoid further abuse.: no_records_hide_address
     help: |
@@ -2512,39 +2512,39 @@ fields:
     datatype: yesnowide
   - Yes. It is necessary to prevent abuse or wrongful removal or concealment of the minor children.: no_records_no_removal
     help: |
-      Select this if you asked the court to prevent ${other_parties[0].name.full(middle="full")} from hiding or removing the children.
+      Select this if you asked the court to prevent ${other_parties[0].name_full()} from hiding or removing the children.
     datatype: yesnowide
 ---
 id: parenting time
 question: |
-  How do you want the court to handle parenting time for the children you have with ${other_parties[0].name.full(middle="full")}?
+  How do you want the court to handle parenting time for the children you have with ${other_parties[0].name_full()}?
 subquestion: |
   This used to be called "visitation" in Illinois.
 fields:
   - The court should:: parenting_time
     datatype: radio
     choices:
-      - Reserve ${other_parties[0].name.full(middle="full")}'s parenting time until a later hearing: reserve
-      - Deny ${other_parties[0].name.full(middle="full")} parenting time (no visits at all): deny
+      - Reserve ${other_parties[0].name_full()}'s parenting time until a later hearing: reserve
+      - Deny ${other_parties[0].name_full()} parenting time (no visits at all): deny
         help: |
           You can enter reasons why you want to deny parenting time on the next screen.
-      - Restrict ${other_parties[0].name.full(middle="full")}'s parenting time (allow visits with limits): restrict
+      - Restrict ${other_parties[0].name_full()}'s parenting time (allow visits with limits): restrict
         help: |
           You can enter reasons why you want to restrict parenting time on the next screen.
-      - Grant ${other_parties[0].name.full(middle="full")} parenting (allow visits according to schedule): grant
+      - Grant ${other_parties[0].name_full()} parenting (allow visits according to schedule): grant
 
 ---
 id: restrict or deny parenting time reasons
 question: |
   % if parenting_time == "restrict":
-  Why do you want to restrict ${other_parties[0].name.full(middle="full")}'s parenting time?
+  Why do you want to restrict ${other_parties[0].name_full()}'s parenting time?
   % else:
-  Why do you want to deny ${other_parties[0].name.full(middle="full")} any parenting time?
+  Why do you want to deny ${other_parties[0].name_full()} any parenting time?
   % endif  
 subquestion: |
   Check all that apply.
 fields:
-  - ${other_parties[0].name.full(middle="full")} is likely to:: restrict_or_deny_pt_reasons
+  - ${other_parties[0].name_full()} is likely to:: restrict_or_deny_pt_reasons
     datatype: checkboxes
     none of the above: False
     choices:
@@ -2557,7 +2557,7 @@ id: parenting time format
 question: |
   How do you want to tell the court about your parenting time schedule?
 subquestion: |
-  Your parenting time schedule should include days and times when ${other_parties[0].name.full(middle="full")} will be able to visit the children.
+  Your parenting time schedule should include days and times when ${other_parties[0].name_full()} will be able to visit the children.
 fields:
   - no label: pt_format
     datatype: radio
@@ -2574,7 +2574,7 @@ fields:
 ---
 id: parenting time weekdays
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to have parenting time on weekdays?
+  Do you want ${other_parties[0].name_full()} to have parenting time on weekdays?
 subquestion: |
   You can pick which weekdays and times on the next screen.
   
@@ -2585,7 +2585,7 @@ fields:
 ---
 id: parenting time weekday schedule
 question: |
-  What weekday parenting time schedule do you want ${other_parties[0].name.full(middle="full")} to have?
+  What weekday parenting time schedule do you want ${other_parties[0].name_full()} to have?
 fields:
   - Days: pt_weekday_days
     datatype: checkboxes
@@ -2606,7 +2606,7 @@ fields:
 ---
 id: parenting time weekends
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to have parenting time on weekends?
+  Do you want ${other_parties[0].name_full()} to have parenting time on weekends?
 subquestion: |
   You can pick weekend days and times on the next screen.
 fields:
@@ -2615,7 +2615,7 @@ fields:
 ---
 id: parenting time weekend schedule
 question: |
-  What weekend parenting time schedule do you want ${other_parties[0].name.full(middle="full")} to have?
+  What weekend parenting time schedule do you want ${other_parties[0].name_full()} to have?
 fields:
   - How often?: pt_weekend_cadence
     datatype: radio
@@ -2661,7 +2661,7 @@ fields:
 ---
 id: parenting time holiday schedule
 question: |
-  What holiday parenting time schedule do you want ${other_parties[0].name.full(middle="full")} to have?
+  What holiday parenting time schedule do you want ${other_parties[0].name_full()} to have?
 fields:
   - List holidays by name or date and include times: pt_holiday_list
     input type: area
@@ -2680,7 +2680,7 @@ fields:
 ---
 id: parenting time supervised
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")}'s parenting time to be supervised?
+  Do you want ${other_parties[0].name_full()}'s parenting time to be supervised?
 subquestion: |
   You can name an adult to supervise parenting time. In some places, an official supervised visitation center may be available.
 fields:
@@ -2722,14 +2722,14 @@ fields:
 ---
 id: parenting time location identified
 question: |
-  Do you know where you want ${other_parties[0].name.full(middle="full")}'s parenting time to happen?
+  Do you know where you want ${other_parties[0].name_full()}'s parenting time to happen?
 fields:
   - no label: pt_location_identified
     datatype: yesnoradio
   - note: |
       Where will parenting time happen?
       
-      **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name.full(middle="full")}.
+      **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name_full()}.
 
       **Note:** The forms do not require a ZIP code for this address. 
     show if: pt_location_identified
@@ -2763,7 +2763,7 @@ fields:
     datatype: radio
     choices:
       - I will provide transportation.: petitioner
-      - ${other_parties[0].name.full(middle="full")} will provide transportation.: respondent
+      - ${other_parties[0].name_full()} will provide transportation.: respondent
       - Someone else will provide transportation.: other
       - I will figure this out later.: later
   - note: |
@@ -2803,7 +2803,7 @@ fields:
   - note: |
       Where will pickup for parenting time happen?
       
-      **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name.full(middle="full")}.
+      **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name_full()}.
 
       **Note:** The forms do not require a ZIP code for this address.
     show if: pt_separate_pickup_location
@@ -2835,7 +2835,7 @@ fields:
   - note: |
       Where will the return from parenting time happen?
       
-      **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name.full(middle="full")}.
+      **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name_full()}.
 
       **Note:** The forms do not require a ZIP code for this address.
     show if: pt_separate_return_location
@@ -2858,13 +2858,13 @@ fields:
 ---
 id: immediate return after parenting time
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to return the children immediately after parenting time?
+  Do you want ${other_parties[0].name_full()} to return the children immediately after parenting time?
 subquestion: |
   You can ask that the children are returned directly to you or to someone you choose. 
 fields:
   - no label: pt_immediate_return
     datatype: yesnoradio
-  - Who should ${other_parties[0].name.full(middle="full")} return the children to at the end of parenting time?: pt_return_person_choice
+  - Who should ${other_parties[0].name_full()} return the children to at the end of parenting time?: pt_return_person_choice
     datatype: radio
     choices:
       - Me: Me
@@ -2903,7 +2903,7 @@ question: |
 subquestion: |
   The court can order that you will get or keep control of personal property. This is called having **possession** of the property.
   
-  These can be things that you currently have with you or things you want ${other_parties[0].name.full(middle="full")} to return to you. For example: your car, clothing, or phone.
+  These can be things that you currently have with you or things you want ${other_parties[0].name_full()} to return to you. For example: your car, clothing, or phone.
 fields:
   - no label: award_personal_property
     datatype: yesnoradio
@@ -2919,7 +2919,7 @@ subquestion: |
   If you are listing a car, include the year, make, and model. For example: 2019 Chevy Malibu.
 fields:
   - Item name: petitioner_personal_property[i].name.text
-  - Do you want the court to order ${other_parties[0].name.full(middle="full")} to return it to you?: petitioner_personal_property[i].respo_has
+  - Do you want the court to order ${other_parties[0].name_full()} to return it to you?: petitioner_personal_property[i].respo_has
     datatype: yesnoradio
 ---
 id: any other petitioner personal property to award
@@ -2950,9 +2950,9 @@ code: |
 ---
 id: return petitioner property to whom
 question: |
-  Who should ${other_parties[0].name.full(middle="full")} return your property to?
+  Who should ${other_parties[0].name_full()} return your property to?
 subquestion: |
-  **Note:** You can ask that another person or law enforcement be present when ${other_parties[0].name.full(middle="full")} returns your property. You can choose this on another screen.
+  **Note:** You can ask that another person or law enforcement be present when ${other_parties[0].name_full()} returns your property. You can choose this on another screen.
 fields:
   - no label: return_property_person
     datatype: radio
@@ -2982,20 +2982,20 @@ fields:
 ---
 id: why respondent should return property
 question: |
-  Why should ${other_parties[0].name.full(middle="full")} return the property?
+  Why should ${other_parties[0].name_full()} return the property?
 subquestion: | 
-  You said ${other_parties[0].name.full(middle="full")} should return these items: ${ comma_and_list([item.name.text for item in petitioner_personal_property if item.respo_has == True]) }.
+  You said ${other_parties[0].name_full()} should return these items: ${ comma_and_list([item.name.text for item in petitioner_personal_property if item.respo_has == True]) }.
 fields:
   - no label: return_property_reason
     datatype: radio
     choices:
       - I own the property.: petitioner owns
       - We both own the property, but not having it would be harder on me. It would put me at risk for abuse or sharing is not practical.: both own
-      - I am married to ${other_parties[0].name.full(middle="full")}, and we have filed for divorce.: divorce
+      - I am married to ${other_parties[0].name_full()}, and we have filed for divorce.: divorce
 ---
 id: any property to return to respondent
 question: |
-  Is there any personal property ${other_parties[0].name.full(middle="full")} will need returned to them right away?
+  Is there any personal property ${other_parties[0].name_full()} will need returned to them right away?
 subquestion: |
   This can be things like clothes, medicine, or other items.
 fields:
@@ -3004,7 +3004,7 @@ fields:
 ---
 id: respondent property
 question: |
-  What personal property should be returned to ${other_parties[0].name.full(middle="full")}?
+  What personal property should be returned to ${other_parties[0].name_full()}?
 fields:
   - no label: respo_property
     datatype: checkboxes
@@ -3023,13 +3023,13 @@ fields:
 ---
 id: respondent one time right to enter
 question: |
-  Should ${other_parties[0].name.full(middle="full")} be allowed to enter the home **only one time** to get their personal property?
+  Should ${other_parties[0].name_full()} be allowed to enter the home **only one time** to get their personal property?
 subquestion: |
-  You can require that a law enforcement officer or another person is present when ${other_parties[0].name.full(middle="full")} gets their property.
+  You can require that a law enforcement officer or another person is present when ${other_parties[0].name_full()} gets their property.
 fields:
   - no label: respondent_one_time_entry
     datatype: yesnoradio
-  - Who should be present when ${other_parties[0].name.full(middle="full")} gets their property?: res_property_transfer_person
+  - Who should be present when ${other_parties[0].name_full()} gets their property?: res_property_transfer_person
     datatype: radio
     choices:
       - Law enforcement: police
@@ -3062,7 +3062,7 @@ id: know property transfer address
 question: |
   Do you know where you want the personal property transfer to happen?
 subquestion: |
-  This is where you will get your property back from ${other_parties[0].name.full(middle="full")}. 
+  This is where you will get your property back from ${other_parties[0].name_full()}. 
   
   You may want this to happen at a police department or sheriff's office. You can enter the address on the next screen.
 fields:
@@ -3075,7 +3075,7 @@ question: |
 subquestion: |
   This can be at a police department or sheriff's office.
   
-  **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name.full(middle="full")}.  
+  **This address will appear on your court papers.** Do not list a location you want to keep hidden from ${other_parties[0].name_full()}.  
 fields:
   - Street address: property_transfer_location.address
     address autocomplete: True
@@ -3150,7 +3150,7 @@ id: any pets to protect
 question: |
   Do you want the court to give you possession of family pets or other animals?
 subquestion: |
-  The court can order ${other_parties[0].name.full(middle="full")} to stay away from the pets and forbid them from taking, hiding, or harming the pets.
+  The court can order ${other_parties[0].name_full()} to stay away from the pets and forbid them from taking, hiding, or harming the pets.
 fields:
   - no label: possession_of_animals
     datatype: yesnoradio
@@ -3183,7 +3183,7 @@ id: want cell phone account separation
 question: |
   Do you want the court to order that your cell phone accounts be separated?
 subquestion: |
-  If you or your children are on ${other_parties[0].name.full(middle="full")}'s cell phone account, you can ask the court to separate the accounts. You will be responsible for paying the cell phone service of the separate account. 
+  If you or your children are on ${other_parties[0].name_full()}'s cell phone account, you can ask the court to separate the accounts. You will be responsible for paying the cell phone service of the separate account. 
 fields:
   - no label: separate_phone_service
     datatype: yesnoradio
@@ -3197,7 +3197,7 @@ fields:
   - no label: phone_account_holder
     datatype: radio
     choices:
-      - ${other_parties[0].name.full(middle="full")}: respondent
+      - ${other_parties[0].name_full()}: respondent
       - Someone else: other
   - First: other_phone_account_holder.name.first
     show if:
@@ -3228,7 +3228,7 @@ fields:
     maxlength: 25
     help: |
       Examples: Verizon or T-Mobile
-  - ${other_parties[0].name.full(middle="full")}'s phone number: billing_phone_number
+  - ${other_parties[0].name_full()}'s phone number: billing_phone_number
     datatype: al_international_phone
 ---
 id: cell phone number to separate
@@ -3273,19 +3273,19 @@ question: |
 subquestion: |
   We already asked about property that the court should order that you can keep or be returned to you.
   
-  The court can also order ${other_parties[0].name.full(middle="full")} not to take, hide, damage, or dispose of property. This can include personal property like your car or real estate like your apartment or house. It can include the spaces inside and outside the property as well as things that are inside the property.
+  The court can also order ${other_parties[0].name_full()} not to take, hide, damage, or dispose of property. This can include personal property like your car or real estate like your apartment or house. It can include the spaces inside and outside the property as well as things that are inside the property.
 
   **Note:** If you want these protections, you will need to describe the items, including property address, on your court papers.
   
 fields:
-  - Is there property you want to protect from ${other_parties[0].name.full(middle="full")}?: restrict_other_property
+  - Is there property you want to protect from ${other_parties[0].name_full()}?: restrict_other_property
     datatype: yesnoradio
 ---
 id: restricted property
 question: |
-  What property should be protected from ${other_parties[0].name.full(middle="full")}?
+  What property should be protected from ${other_parties[0].name_full()}?
 subquestion: |
-  The court can order ${other_parties[0].name.full(middle="full")} not to take, hide, damage, or dispose of property. This can include personal property or real estate.
+  The court can order ${other_parties[0].name_full()} not to take, hide, damage, or dispose of property. This can include personal property or real estate.
 
   Check all that apply.
 fields:
@@ -3331,7 +3331,7 @@ fields:
 ---
 id: why property should be restricted
 question: |
-  Why should the property be protected from ${other_parties[0].name.full(middle="full")}?
+  Why should the property be protected from ${other_parties[0].name_full()}?
 subquestion: | 
   You said this property should be protected:
 
@@ -3356,11 +3356,11 @@ fields:
     choices:
       - I own the property.: petitioner
       - We both own the property, but not having it would be harder on me. It would put me at risk for abuse or sharing is not practical.: both
-      - I am married to ${other_parties[0].name.full(middle="full")}, and we have filed for divorce.: divorce
+      - I am married to ${other_parties[0].name_full()}, and we have filed for divorce.: divorce
 ---
 id: restrict resources of elderly petitioner
 question: |
-  Should ${other_parties[0].name.full(middle="full")} be ordered not to improperly use an elderly person's money or property for themselves?
+  Should ${other_parties[0].name_full()} be ordered not to improperly use an elderly person's money or property for themselves?
 subquestion: |
   If the Order of Protection will include any elderly people, this can protect their financial resources and property.
 fields:
@@ -3373,9 +3373,9 @@ fields:
 ---
 id: request temporary support
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to pay temporary child support?
+  Do you want ${other_parties[0].name_full()} to pay temporary child support?
 subquestion: |
-  The court can order temporary child support only after ${other_parties[0].name.full(middle="full")} has received written notice or attended the court hearing where this is decided.
+  The court can order temporary child support only after ${other_parties[0].name_full()} has received written notice or attended the court hearing where this is decided.
   
   **Important:** Even if the judge can't award temporary support at the first hearing, it is easier to ask for it now. Otherwise, you will have to amend your Petition later.
 fields:
@@ -3384,20 +3384,20 @@ fields:
 ---
 id: request maintenance
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to pay temporary maintenance?
+  Do you want ${other_parties[0].name_full()} to pay temporary maintenance?
 subquestion: |
   Maintenance used to be called "spousal support" or "alimony."
   
-  The court can order temporary maintenance only after ${other_parties[0].name.full(middle="full")} has received written notice or attended the court hearing where this is decided.
+  The court can order temporary maintenance only after ${other_parties[0].name_full()} has received written notice or attended the court hearing where this is decided.
 fields:
   - no label: temp_maintenance
     datatype: yesnoradio
 ---
 id: expenses
 question: |
-  Do you want ${other_parties[0].name.full(middle="full")} to pay for losses caused by abuse, neglect, or exploitation?
+  Do you want ${other_parties[0].name_full()} to pay for losses caused by abuse, neglect, or exploitation?
 subquestion: |
-  **Note:** The court can order ${other_parties[0].name.full(middle="full")} to pay only after they have received written notice or attended the court hearing where this is decided.
+  **Note:** The court can order ${other_parties[0].name_full()} to pay only after they have received written notice or attended the court hearing where this is decided.
 
   If you do not know the exact amount you can estimate. Bring receipts, proof of payment, and repair estimates to court if you have them.
 fields:
@@ -3406,7 +3406,7 @@ fields:
     disable others: True
   - note: |
       ---
-      Yes. I want the court to order ${other_parties[0].name.full(middle="full")} to pay for:
+      Yes. I want the court to order ${other_parties[0].name_full()} to pay for:
   - Medical expenses: expenses_medical
     datatype: yesnowide
   - "Amount": expenses_medical_amount
@@ -3473,19 +3473,19 @@ validation code: |
 id: firearms threat
 question: |
   % if minor_kids_with_respondent or protect_petitioner_kids:
-  Is ${other_parties[0].name.full(middle="full")} a threat to the physical safety of you or your children?
+  Is ${other_parties[0].name_full()} a threat to the physical safety of you or your children?
   % else:
-  Is ${other_parties[0].name.full(middle="full")} a threat to your physical safety?
+  Is ${other_parties[0].name_full()} a threat to your physical safety?
   % endif
 subquestion: |
-  Just knowing that ${other_parties[0].name.full(middle="full")} has a **weapon** can be a threat if you are afraid they could use it against you.
+  Just knowing that ${other_parties[0].name_full()} has a **weapon** can be a threat if you are afraid they could use it against you.
 
   ${ collapse_template(dv_risk_factors) }
 
   % if minor_kids_with_respondent or protect_petitioner_kids:
-  **Note:** If ${other_parties[0].name.full(middle="full")} threatened you or your children with a weapon, be sure to explain the threats, the weapon and its location in the [**What happened**](${ url_action('section_incidents') }) section. Describe the weapon as best you can. Threats are incidents of abuse that are important to your case.
+  **Note:** If ${other_parties[0].name_full()} threatened you or your children with a weapon, be sure to explain the threats, the weapon and its location in the [**What happened**](${ url_action('section_incidents') }) section. Describe the weapon as best you can. Threats are incidents of abuse that are important to your case.
   % else:
-  **Note:** If ${other_parties[0].name.full(middle="full")} threatened you with a weapon, be sure to explain the threats, the weapon and its location in the [**What happened**](${ url_action('section_incidents') }) section. Describe the weapon as best you can. Threats are incidents of abuse that are important to your case.
+  **Note:** If ${other_parties[0].name_full()} threatened you with a weapon, be sure to explain the threats, the weapon and its location in the [**What happened**](${ url_action('section_incidents') }) section. Describe the weapon as best you can. Threats are incidents of abuse that are important to your case.
   % endif
 fields:
   - no label: firearms_threat
@@ -3495,7 +3495,7 @@ template: dv_risk_factors
 subject: |
   **What other things should I consider?**
 content: |  
-  ${other_parties[0].name.full(middle="full")} might be more likely to threaten your safety if:
+  ${other_parties[0].name_full()} might be more likely to threaten your safety if:
 
   * You recently separated from them or are currently separating from them.
   * They tried to strangle or choke you.
@@ -3512,8 +3512,8 @@ question: |
 subquestion: |
   As part of an Order of Protection, the court can:
   
-  * Order ${other_parties[0].name.full(middle="full")} to **surrender firearms** to law enforcement, and
-  * Issue a **search warrant** be issued so law enforcement can search ${other_parties[0].name.full(middle="full")}'s property to seize firearms.
+  * Order ${other_parties[0].name_full()} to **surrender firearms** to law enforcement, and
+  * Issue a **search warrant** be issued so law enforcement can search ${other_parties[0].name_full()}'s property to seize firearms.
   
   Firearms can include:
   
@@ -3525,17 +3525,17 @@ subquestion: |
   ${ collapse_template(firearms_help) }
   
   % if minor_kids_with_respondent or protect_petitioner_kids:
-  Reminder: If ${other_parties[0].name.full(middle="full")} threatened you or your children with a weapon, be sure to explain the threat and the weapon in the [**What happened**](${ url_action('section_incidents') }) section.
+  Reminder: If ${other_parties[0].name_full()} threatened you or your children with a weapon, be sure to explain the threat and the weapon in the [**What happened**](${ url_action('section_incidents') }) section.
   % else:
-  Reminder: If ${other_parties[0].name.full(middle="full")} threatened you with a weapon, be sure to explain the threat and the weapon in the [**What happened**](${ url_action('section_incidents') }) section.
+  Reminder: If ${other_parties[0].name_full()} threatened you with a weapon, be sure to explain the threat and the weapon in the [**What happened**](${ url_action('section_incidents') }) section.
   % endif
 
 fields:
   - Do you want the court to order any firearms relief? (Check all that apply.): firearms_relief
     datatype: checkboxes
     choices:
-      - Yes, I want ${other_parties[0].name.full(middle="full")} to **surrender firearms** to law enforcement.: surrender
-      - Yes, I want a **search warrant** to be issued so law enforcement can search ${other_parties[0].name.full(middle="full")}'s property and seize fierarms.: warrant
+      - Yes, I want ${other_parties[0].name_full()} to **surrender firearms** to law enforcement.: surrender
+      - Yes, I want a **search warrant** to be issued so law enforcement can search ${other_parties[0].name_full()}'s property and seize fierarms.: warrant
     none of the above: No, I do not want to ask for either of these.
 ---
 template: firearms_help
@@ -3553,7 +3553,7 @@ content: |
 ---
 id: intimate partner
 question: |
-  Is ${other_parties[0].name.full(middle="full")} a current or former intimate partner?
+  Is ${other_parties[0].name_full()} a current or former intimate partner?
 subquestion: |
   This means you were in a romantic relationship with them. This information may be part of the court's decision to remove Respondent's guns.
 fields:
@@ -3568,16 +3568,16 @@ id: remove firearms additional reasons
 question: |
   Reasons why you want the court to issue a search warrant 
 subquestion: |
-  Explain why a search warrant should be issued so that law enforcement can search ${other_parties[0].name.full(middle="full")}'s property and may seize firearms or firearm parts from them.
+  Explain why a search warrant should be issued so that law enforcement can search ${other_parties[0].name_full()}'s property and may seize firearms or firearm parts from them.
   
   Check all that apply.
 fields:
   - no label: warrant_reasons
     datatype: checkboxes
     choices:
-      - ${other_parties[0].name.full(middle="full")} is an immediate threat to the physical safety of the people I want to protect.: threat
-      - ${other_parties[0].name.full(middle="full")} has a firearm or firearm parts that could be used to make a firearm.: has_guns
-      - The firearm or firearm parts are in the residence, vehicle, or other property of ${other_parties[0].name.full(middle="full")}.: location
+      - ${other_parties[0].name_full()} is an immediate threat to the physical safety of the people I want to protect.: threat
+      - ${other_parties[0].name_full()} has a firearm or firearm parts that could be used to make a firearm.: has_guns
+      - The firearm or firearm parts are in the residence, vehicle, or other property of ${other_parties[0].name_full()}.: location
 ---
 id: report of dv
 question: |
@@ -3609,7 +3609,7 @@ fields:
     rows: 2
     maxlength: 75
     required: False
-  - Days and times ${other_parties[0].name.full(middle="full")} will likely be at this location: warrant_location_list[i].days_times
+  - Days and times ${other_parties[0].name_full()} will likely be at this location: warrant_location_list[i].days_times
     input type: area
     rows: 2
     maxlength: 60
@@ -3648,11 +3648,11 @@ code: |
 ---
 id: other helpful warrant info
 question: |
-  Do you have other information about ${other_parties[0].name.full(middle="full")} that might be helpful to law enforcement when they execute the warrant?
+  Do you have other information about ${other_parties[0].name_full()} that might be helpful to law enforcement when they execute the warrant?
 subquestion: |
-  Law enforcement might want to know details about ${other_parties[0].name.full(middle="full")}'s appearance like their skin color or if they wear glasses.
+  Law enforcement might want to know details about ${other_parties[0].name_full()}'s appearance like their skin color or if they wear glasses.
   
-  They also might want to know if ${other_parties[0].name.full(middle="full")}:
+  They also might want to know if ${other_parties[0].name_full()}:
   
   * Has a history of mental illness,
   * Has ever been suicidal, 
@@ -3669,9 +3669,9 @@ fields:
 ---
 id: firearms eop prior notice question
 question: |
-  Are you worried that ${other_parties[0].name.full(middle="full")} might hurt you or the people you want to protect when they learn about the Order of Protection?
+  Are you worried that ${other_parties[0].name_full()} might hurt you or the people you want to protect when they learn about the Order of Protection?
 subquestion: |
-  **Note:** If you are asking for an Emergency Order of Protection, select **Yes** if you think that ${other_parties[0].name.full(middle="full")} might cause physical injury to you or the people you want to protect when they learn about it.
+  **Note:** If you are asking for an Emergency Order of Protection, select **Yes** if you think that ${other_parties[0].name_full()} might cause physical injury to you or the people you want to protect when they learn about it.
 fields:
   - no label: firearms_eop_notice
     datatype: yesnoradio
@@ -3687,13 +3687,13 @@ code: |
 ---
 id: misc remedies
 question: |
-  What else do you want the court to order ${other_parties[0].name.full(middle="full")} to do or to stop doing?
+  What else do you want the court to order ${other_parties[0].name_full()} to do or to stop doing?
 subquestion: |
   % if add_no_contact_language and trial_court_index != 71:
-  Because you are asking the court to order ${other_parties[0].name.full(middle="full")} to stay away and stop communication, "No contact by any means with protected parties" will be added. You can change this below.
+  Because you are asking the court to order ${other_parties[0].name_full()} to stay away and stop communication, "No contact by any means with protected parties" will be added. You can change this below.
   % endif
 fields:
-  - ${other_parties[0].name.full(middle="full")} should be ordered to:: misc_remedies_text
+  - ${other_parties[0].name_full()} should be ordered to:: misc_remedies_text
     input type: area
     rows: 5
     maxlength: 415
@@ -3710,7 +3710,7 @@ id: e-signature
 question: |
   Do you want to add your e-signature to your Petition for Order of Protection?
 subquestion: |
-  This program can put "**/s/ ${users[0].name.full(middle='full')}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${users[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
 
   If you do not add your **{e-signature}**, you must sign your paper forms before you file them.
 
@@ -3786,7 +3786,7 @@ fields:
 ---
 id: service address choice
 question: |
-  Where can ${other_parties[0].name.full(middle="full")} be found?
+  Where can ${other_parties[0].name_full()} be found?
 subquestion: |
   This is where they will be served with Order of Protection court papers.
   
@@ -3803,17 +3803,17 @@ reconsider: True
 code: |
   service_list = []
   if knows_respondent_home == True:
-    service_list.append( { "home": other_parties[0].name.full(middle="full") + "'s home address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
+    service_list.append( { "home": other_parties[0].name_full() + "'s home address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
   else:
     if knows_respondent_home_last == True:
-      service_list.append( { "home": other_parties[0].name.full(middle="full") + "'s last known address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
+      service_list.append( { "home": other_parties[0].name_full() + "'s last known address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
   if knows_respondent_work == True:
-    service_list.append({ "work": other_parties[0].name.full(middle="full")+ "'s work address (" + other_parties[0].work_address.on_one_line(bare=True) + ")" })
+    service_list.append({ "work": other_parties[0].name_full()+ "'s work address (" + other_parties[0].work_address.on_one_line(bare=True) + ")" })
   service_list.append({ "other": "An address I will enter" })
 ---
 id: other service address
 question: |
-  Enter the address where ${other_parties[0].name.full(middle="full")} can be found
+  Enter the address where ${other_parties[0].name_full()} can be found
 fields:
   - Street address: service_address.address
     address autocomplete: True
@@ -3828,14 +3828,14 @@ fields:
 ---    
 id: have another service address
 question: |
-  Do you want to add another address where ${other_parties[0].name.full(middle="full")} can be found?
+  Do you want to add another address where ${other_parties[0].name_full()} can be found?
 fields:
   - no label: has_second_service_address
     datatype: yesnoradio
 ---
 id: second service address choice
 question: |
-  Where else can ${other_parties[0].name.full(middle="full")} be found?
+  Where else can ${other_parties[0].name_full()} be found?
 fields:
   - no label: second_service_address_choice
     datatype: radio
@@ -3845,20 +3845,20 @@ reconsider: True
 code: |
   alt_service_list = []
   if knows_respondent_home == True and service_address_choice != "home":
-    alt_service_list.append( { "home": other_parties[0].name.full(middle="full") + "'s home address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
+    alt_service_list.append( { "home": other_parties[0].name_full() + "'s home address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
   else:
     if knows_respondent_home == False:
       if knows_respondent_home_last == True and service_address_choice != "home":
-        alt_service_list.append( { "home": other_parties[0].name.full(middle="full") + "'s last known address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
+        alt_service_list.append( { "home": other_parties[0].name_full() + "'s last known address (" + other_parties[0].address.on_one_line(bare=True) + ")" })
   if knows_respondent_work == True and service_address_choice != "work":
-    alt_service_list.append({ "work": other_parties[0].name.full(middle="full")+ "'s work address (" + other_parties[0].work_address.on_one_line(bare=True) + ")" })
+    alt_service_list.append({ "work": other_parties[0].name_full()+ "'s work address (" + other_parties[0].work_address.on_one_line(bare=True) + ")" })
   alt_service_list.append({ "other": "An address I will enter" })
 ---
 id: out of state county
 question: |
-  In which county can the sheriff find ${other_parties[0].name.full(middle="full")}?
+  In which county can the sheriff find ${other_parties[0].name_full()}?
 subquestion: |
-  You said the sheriff can serve court papers on ${other_parties[0].name.full(middle="full")} at:
+  You said the sheriff can serve court papers on ${other_parties[0].name_full()} at:
   
   % if service_address_choice == "other":
   * ${ service_address.on_one_line(bare=True) }
@@ -3868,11 +3868,11 @@ subquestion: |
   * ${ other_parties[0].work_address.on_one_line(bare=True) }        
   % endif
   
-  Enter the county below so the sheriff can find ${other_parties[0].name.full(middle="full")}.
+  Enter the county below so the sheriff can find ${other_parties[0].name_full()}.
   
   ${ collapse_template(county_lookup_help) }
 fields:
-  - County where ${other_parties[0].name.full(middle="full")} can be served: service_county
+  - County where ${other_parties[0].name_full()} can be served: service_county
     maxlength: 40
 ---
 template: county_lookup_help
@@ -3883,7 +3883,7 @@ content: |
 ---
 id: second other service address
 question: |
-  Enter another address where ${other_parties[0].name.full(middle="full")} can be found
+  Enter another address where ${other_parties[0].name_full()} can be found
 fields:
   - Street address: second_service_address.address
     address autocomplete: True
@@ -3898,22 +3898,22 @@ fields:
 ---
 id: respondent alt contact info
 question: |
-  Do you know other ways ${other_parties[0].name.full(middle="full")} can be contacted?
+  Do you know other ways ${other_parties[0].name_full()} can be contacted?
 subquestion: |
   You alread told us:
   
   % if other_parties[0].phone_number != "":
-  * ${other_parties[0].name.full(middle="full")}'s phone: ${ phone_number_formatted(other_parties[0].phone_number) }
+  * ${other_parties[0].name_full()}'s phone: ${ phone_number_formatted(other_parties[0].phone_number) }
   % else:
-  * ${other_parties[0].name.full(middle="full")}'s phone: None entered
+  * ${other_parties[0].name_full()}'s phone: None entered
   % endif
   % if other_parties[0].email != "":
-  * ${other_parties[0].name.full(middle="full")}'s email: ${ other_parties[0].email }
+  * ${other_parties[0].name_full()}'s email: ${ other_parties[0].email }
   % else:
-  * ${other_parties[0].name.full(middle="full")}'s email: None entered
+  * ${other_parties[0].name_full()}'s email: None entered
   % endif
    
-  If you do not know other contact information for ${other_parties[0].name.full(middle="full")}, leave these blank.
+  If you do not know other contact information for ${other_parties[0].name_full()}, leave these blank.
 fields:
   - Phone: other_parties[0].phone_number_alt
     datatype: al_international_phone
@@ -3933,7 +3933,7 @@ code: |
 ---
 id: service method
 question: |
-  Who do you want to deliver court papers to ${other_parties[0].name.full(middle="full")}?
+  Who do you want to deliver court papers to ${other_parties[0].name_full()}?
 subquestion: |
   This is called service. In Illinois, **Sheriffs usually serve Orders of Protection.**
   
@@ -3949,13 +3949,13 @@ fields:
 ---
 id: additional service information cook
 question: |
-  What other information will help the sheriff deliver court papers to ${other_parties[0].name.full(middle="full")}?
+  What other information will help the sheriff deliver court papers to ${other_parties[0].name_full()}?
 subquestion: |
   You can add things like:
   
   * Best days and times to serve court papers,
-  * Details about the places where ${other_parties[0].name.full(middle="full")} can be found, and
-  * Information about other people at those locations that can help find ${other_parties[0].name.full(middle="full")}.
+  * Details about the places where ${other_parties[0].name_full()} can be found, and
+  * Information about other people at those locations that can help find ${other_parties[0].name_full()}.
 
   This will not appear on the forms that will be filed with the court. It goes on the Confidential Protective Order Information Sheet for the Sheriff.
 fields:
@@ -3969,9 +3969,9 @@ fields:
 ---
 id: respondent gender cook only
 question: |
-  What is ${other_parties[0].name.full(middle="full")}'s gender?
+  What is ${other_parties[0].name_full()}'s gender?
 subquestion: |
-  This information is used to help law enforcement identify ${other_parties[0].name.full(middle="full")} and enforce the Order of Protection. If you do not know this information, you can leave it blank.
+  This information is used to help law enforcement identify ${other_parties[0].name_full()} and enforce the Order of Protection. If you do not know this information, you can leave it blank.
 fields:
   - Gender (will be public, used by any law enforcement): other_parties[0].gender
     datatype: radio
@@ -3980,7 +3980,7 @@ fields:
       - Male: Male
       - Female: Female
       - Other: other
-  - ${other_parties[0].name.full(middle="full")}'s gender (will be public, used by any law enforcement): respondent_gender_other
+  - ${other_parties[0].name_full()}'s gender (will be public, used by any law enforcement): respondent_gender_other
     maxlength: 20
     required: False
     show if:
@@ -3999,7 +3999,7 @@ fields:
       - Transgender man / Transmasculine: transmasc
       - Nonbinary / Gender non-conforming: nonbinary
       - Other: other
-  - ${other_parties[0].name.full(middle="full")}'s gender identity (confidential, used by Cook County sheriff only): respondent_gender_other_cook
+  - ${other_parties[0].name_full()}'s gender identity (confidential, used by Cook County sheriff only): respondent_gender_other_cook
     maxlength: 20
     required: False
     show if:
@@ -4012,11 +4012,11 @@ fields:
       - Male: male
       - Female: female
     help: |
-      Sex assigned at birth refers to the sex or gender marker on ${other_parties[0].name.full(middle="full")}'s original birth certificate. If they were born intersex, you may want to mention that in gender/other.
+      Sex assigned at birth refers to the sex or gender marker on ${other_parties[0].name_full()}'s original birth certificate. If they were born intersex, you may want to mention that in gender/other.
 ---
 id: respondent race
 question: |
-  What is ${other_parties[0].name.full(middle="full")}'s race?
+  What is ${other_parties[0].name_full()}'s race?
 subquestion: |
   This information is used to help enforce the Order of Protection.
 fields:
@@ -4036,7 +4036,7 @@ fields:
       - 2 or more races: Multiracial
       - Other: other
       - Unknown: unknown
-  - ${other_parties[0].name.full(middle="full")}'s race: respondent_race_other
+  - ${other_parties[0].name_full()}'s race: respondent_race_other
     maxlength: 25
     show if:
       variable: other_parties[0].race
@@ -4044,7 +4044,7 @@ fields:
 ---
 id: respondent physical characteristics Cook
 question: |
-  Tell us about ${other_parties[0].name.full(middle="full")}'s appearance
+  Tell us about ${other_parties[0].name_full()}'s appearance
 subquestion: |
   This information is used to help enforce the Order of Protection.
   
@@ -4082,7 +4082,7 @@ fields:
       - Brown: Brown
       - Dark brown: Dark brown
       - Other: other
-  - ${other_parties[0].name.full(middle="full")}'s skin color: respondent_skin_other
+  - ${other_parties[0].name_full()}'s skin color: respondent_skin_other
     maxlength: 30
     show if:
       variable: other_parties[0].skin
@@ -4104,7 +4104,7 @@ fields:
     required: False
     help: |
       Try to be descritive. Examples: tattoos on hands, facial scars, birthmarks, mustache, beard
-  - Does ${other_parties[0].name.full(middle="full")} wear glasses?: other_parties[0].glasses
+  - Does ${other_parties[0].name_full()} wear glasses?: other_parties[0].glasses
     datatype: radio
     required: False
     choices: 
@@ -4114,20 +4114,20 @@ fields:
 ---
 id: respondent more identifying info Cook
 question: |
-  Anything else about ${other_parties[0].name.full(middle="full")}?
+  Anything else about ${other_parties[0].name_full()}?
 subquestion: |
   This information is used to help enforce the Order of Protection.
   
   If you do not know, leave blank.
 fields:
-  - Other names used by ${other_parties[0].name.full(middle="full")}:: alias_names
+  - Other names used by ${other_parties[0].name_full()}:: alias_names
     input type: area
     rows: 3
     maxlength: 120
     required: False
     help: |
       This could be a name from an earlier marriage or a nickname. If there is more than one, separate by commas.
-  - Is ${other_parties[0].name.full(middle="full")} on court-ordered probation?: respondent_on_probation
+  - Is ${other_parties[0].name_full()} on court-ordered probation?: respondent_on_probation
     datatype: radio
     choices:
       - Yes: Yes
@@ -4144,11 +4144,11 @@ fields:
 ---
 id: respondent caution
 question: |
-  Are there reasons the sheriff should use caution when approaching ${other_parties[0].name.full(middle="full")}?
+  Are there reasons the sheriff should use caution when approaching ${other_parties[0].name_full()}?
 subquestion: |
   Check all that apply.
 fields:
-  - ${other_parties[0].name.full(middle="full")}: caution_reasons
+  - ${other_parties[0].name_full()}: caution_reasons
     datatype: checkboxes
     none of the above: False
     required: False
@@ -4169,7 +4169,7 @@ fields:
 ---
 id: car information for cook
 question: |
-  Enter details about ${other_parties[0].name.full(middle="full")}'s car
+  Enter details about ${other_parties[0].name_full()}'s car
 subquestion: |
   This information is used to help enforce the Order of Protection.
   
@@ -4208,20 +4208,20 @@ fields:
 ---
 id: any previous cook cases
 question: |
-  Have you filed any divorce or parentage cases with ${other_parties[0].name.full(middle="full")} in Cook County before?
+  Have you filed any divorce or parentage cases with ${other_parties[0].name_full()} in Cook County before?
 subquestion: |
   This will help the court clerk in Cook County assign your case to the correct location. If you were involved in more than one, choose the most recent.
 fields:
   - no label: previous_cook_case_type
     datatype: radio
     choices:
-      - I was in an earlier divorce case with ${other_parties[0].name.full(middle="full")}.: divorce
-      - I was in an earlier parentage case with ${other_parties[0].name.full(middle="full")} involving children we had together.: parentage
+      - I was in an earlier divorce case with ${other_parties[0].name_full()}.: divorce
+      - I was in an earlier parentage case with ${other_parties[0].name_full()} involving children we had together.: parentage
       - No earlier divorce or parentage cases were filed in Cook County.: none
 ---
 id: previous cook case details
 question: |
-  Tell us about the ${ previous_cook_case_type } case with ${other_parties[0].name.full(middle="full")} in Cook County
+  Tell us about the ${ previous_cook_case_type } case with ${other_parties[0].name_full()} in Cook County
 subquestion: |
   If there is more than one, enter information about the most recent.
 fields:
@@ -4381,12 +4381,12 @@ content: |
 template: clerk_email
 subject: |
   % if preferred_contact == "phone":
-  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name.full(middle="full") } v. ${other_parties[0].name.full(middle="full")} - contact: ${ phone_number_formatted(safe_phone_number) }
+  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name_full() } v. ${other_parties[0].name_full()} - contact: ${ phone_number_formatted(safe_phone_number) }
   % else:
-  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name.full(middle="full") } v. ${other_parties[0].name.full(middle="full")} - contact: ${ safe_email }
+  Emergency Order of Protection Petition - ILAO Easy Form - ${ users[0].name_full() } v. ${other_parties[0].name_full()} - contact: ${ safe_email }
   % endif  
 content: |
-  ${ users[0].name.full(middle="full") } is filing for a Petition for Order of Protection against ${other_parties[0].name.full(middle="full")}.
+  ${ users[0].name_full() } is filing for a Petition for Order of Protection against ${other_parties[0].name_full()}.
   
   Petitioner safe email address: ${ safe_email }
   
@@ -4910,49 +4910,49 @@ attachment:
     - "civil_proceeding": True
     - "petitioner": |
         % if users[0].birthdate != "":
-        ${ users[0].name.full(middle="full") + ", (DOB: " + users[0].birthdate + ")" }
+        ${ users[0].name_full() + ", (DOB: " + users[0].birthdate + ")" }
         % else:
-        ${ users[0].name.full(middle="full") }
+        ${ users[0].name_full() }
         % endif
     - "petitioner__2": |
         % if protect_petitioner and protect_obo_minor: 
-        ${ users[0].name.full(middle="full") + " and on behalf of minor: " + obo_minor.name.full(middle="full")}
+        ${ users[0].name_full() + " and on behalf of minor: " + obo_minor.name_full()}
         % elif protect_petitioner:
-        ${ users[0].name.full(middle="full") }
+        ${ users[0].name_full() }
         % elif protect_obo_minor:
-        ${ "On behalf of minor: " + obo_minor.name.full(middle="full")}
+        ${ "On behalf of minor: " + obo_minor.name_full()}
         % else:
         ${""}
-        % endif    - "petitioner__3": ${ users[0].name.full(middle="full") }
+        % endif    - "petitioner__3": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
     - "obo_high_risk_adult_cb": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
     - "respondent": |
         % if knows_respondent_dob == "exact" and other_parties[0].birthdate != "":
-        ${ other_parties[0].name.full(middle="full") + ", (DOB: " + other_parties[0].birthdate + ")" }
+        ${ other_parties[0].name_full() + ", (DOB: " + other_parties[0].birthdate + ")" }
         % else:
-        ${ other_parties[0].name.full(middle="full") }
+        ${ other_parties[0].name_full() }
         % endif
     - "protect_petitioner": ${ protect_petitioner }
     - "protect_shared_kids": ${ protect_shared_kids }
-    - "shared_kids_list": ${ comma_and_list([person.name.full(middle="full") for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
+    - "shared_kids_list": ${ comma_and_list([person.name_full() for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
     - "protect_petitioner_kids": ${ protect_petitioner_kids }
     - "petitioner_kids_list": ${ petitioner_kids.full_names() if protect_petitioner_kids else '' }
     - "protect_dependent_adult": ${ protect_dependent_adult }
     - "protect_high_risk_adult": ${ protect_high_risk_adult }
     - "protect_other_hh_members": ${ protect_other_hh_members }
     - "other_hh_members_list": ${ other_hh_members.full_names() if protect_other_hh_members else '' }
-    - "dependent_adult": ${ dependent_adult.name.full(middle="full") if protect_dependent_adult else '' }
-    - "high_risk_adult": ${ high_risk_adult.name.full(middle="full") if protect_high_risk_adult else '' }
+    - "dependent_adult": ${ dependent_adult.name_full() if protect_dependent_adult else '' }
+    - "high_risk_adult": ${ high_risk_adult.name_full() if protect_high_risk_adult else '' }
 
     - "eop": ${ eop }
     - "pop": ${ pop }
@@ -5405,7 +5405,7 @@ attachment:
       # page 7    
     - "care_and_possession_of_children": ${ minor_kids_with_respondent } 
     - "minor_kids_with_respondent": ${ minor_kids_with_respondent }
-    - "shared_kids_1_name": ${ shared_kids[0].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_1_name": ${ shared_kids[0].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_1_age": ${ shared_kids[0].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_1_state": ${ shared_kids[0].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_1_pet_par": ${ True if minor_kids_with_respondent and shared_kids[0].pet_parentage == True else "" }
@@ -5413,7 +5413,7 @@ attachment:
     - "shared_kids_1_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[0].pet_parentage == None and shared_kids[0].res_parentage == None) else "" }
     - "shared_kids_1_include_yes": ${ shared_kids[0].protect if minor_kids_with_respondent else '' }
     - "shared_kids_1_include_no": ${ True if minor_kids_with_respondent and shared_kids[0].protect == False else '' }
-    - "shared_kids_2_name": ${ shared_kids[1].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_2_name": ${ shared_kids[1].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_2_age": ${ shared_kids[1].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_2_state": ${ shared_kids[1].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_2_pet_par": ${ True if minor_kids_with_respondent and shared_kids[1].pet_parentage == True else "" }
@@ -5421,7 +5421,7 @@ attachment:
     - "shared_kids_2_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[1].pet_parentage == None and shared_kids[1].res_parentage == None) else "" }
     - "shared_kids_2_include_yes": ${ shared_kids[1].protect if minor_kids_with_respondent else '' }
     - "shared_kids_2_include_no": ${ True if minor_kids_with_respondent and shared_kids[1].protect == False else '' }
-    - "shared_kids_3_name": ${ shared_kids[2].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_3_name": ${ shared_kids[2].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_3_age": ${ shared_kids[2].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_3_state": ${ shared_kids[2].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_3_pet_par": ${ True if minor_kids_with_respondent and shared_kids[2].pet_parentage == True else "" }
@@ -5429,7 +5429,7 @@ attachment:
     - "shared_kids_3_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[2].pet_parentage == None and shared_kids[2].res_parentage == None) else "" }
     - "shared_kids_3_include_yes": ${ shared_kids[2].protect if minor_kids_with_respondent else '' }
     - "shared_kids_3_include_no": ${ True if minor_kids_with_respondent and shared_kids[2].protect == False else '' }
-    - "shared_kids_4_name": ${ shared_kids[3].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_4_name": ${ shared_kids[3].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_4_age": ${ shared_kids[3].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_4_state": ${ shared_kids[3].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_4_pet_par": ${ True if minor_kids_with_respondent and shared_kids[3].pet_parentage == True else "" }
@@ -5437,7 +5437,7 @@ attachment:
     - "shared_kids_4_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[3].pet_parentage == None and shared_kids[3].res_parentage == None) else "" }
     - "shared_kids_4_include_yes": ${ shared_kids[3].protect if minor_kids_with_respondent else '' }
     - "shared_kids_4_include_no": ${ True if minor_kids_with_respondent and shared_kids[3].protect == False else '' }
-    - "shared_kids_5_name": ${ shared_kids[4].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_5_name": ${ shared_kids[4].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_5_age": ${ shared_kids[4].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_5_state": ${ shared_kids[4].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_5_pet_par": ${ True if minor_kids_with_respondent and shared_kids[4].pet_parentage == True else "" }
@@ -5445,7 +5445,7 @@ attachment:
     - "shared_kids_5_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[4].pet_parentage == None and shared_kids[4].res_parentage == None) else "" }
     - "shared_kids_5_include_yes": ${ shared_kids[4].protect if minor_kids_with_respondent else '' }
     - "shared_kids_5_include_no": ${ True if minor_kids_with_respondent and shared_kids[4].protect == False else '' }
-    - "shared_kids_6_name": ${ shared_kids[5].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_6_name": ${ shared_kids[5].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_6_age": ${ shared_kids[5].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_6_state": ${ shared_kids[5].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_6_pet_par": ${ True if minor_kids_with_respondent and shared_kids[5].pet_parentage == True else "" }
@@ -5464,13 +5464,13 @@ attachment:
 
     - "caretaker_respondent": ${ True if (primary_caretaker == "respondent" and minor_kids_with_respondent) else '' }
     - "caretaker_other": ${ True if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
-    - "other_caretaker_name": ${ other_caretaker.name.full(middle="full") if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
+    - "other_caretaker_name": ${ other_caretaker.name_full() if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
     - "other_caretaker_address": ${ other_caretaker.address.on_one_line(bare=True) if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
     - "care_and_possession_cb": ${ True if physical_care_of_children or return_children_to == "petitioner" or return_children_to == "other" or no_removal_school or ((schools[0].hide or schools[1].hide) and stay_away_schools and minor_kids_with_respondent) else '' }
 
     - "physical_care_of_children": ${ True if physical_care_of_children and minor_kids_with_respondent else '' }
     - "return_children_possession": ${ True if (return_children_to == "petitioner" or return_children_to == "other") and minor_kids_with_respondent else '' }
-    - "return_children_other_person": ${ return_children_other_person.name.full(middle="full") if return_children_to == "other" and minor_kids_with_respondent else '' }
+    - "return_children_other_person": ${ return_children_other_person.name_full() if return_children_to == "other" and minor_kids_with_respondent else '' }
     - "no_removal_school": ${ True if no_removal_school and minor_kids_with_respondent else '' }
     - "confidential_schools__2": ${ True if (schools[0].hide or schools[1].hide) and stay_away_schools and minor_kids_with_respondent else False }
     - "temp_custody_cb": ${ True if temp_custody_of_children and minor_kids_with_respondent else '' }
@@ -5512,7 +5512,7 @@ attachment:
         % elif pt_transportation == "respondent" and (parenting_time == "restrict" or parenting_time == "grant"):
         ${ "Respondent" }
         % elif pt_transportation == "other" and (parenting_time == "restrict" or parenting_time == "grant"):
-        ${ pt_transportation_person.name.full(middle="full") }
+        ${ pt_transportation_person.name_full() }
         % else:
         ${ "" }
         % endif
@@ -5556,13 +5556,13 @@ attachment:
         ${ "" }
         % endif          
     - "pt_supervised": ${ True if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
-    - "pt_supervisor_name": ${ pt_supervisor.name.full(middle="full") if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
+    - "pt_supervisor_name": ${ pt_supervisor.name_full() if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_supervised_center_cb": ${ True if pt_supervised == True and pt_supervisor_type == "agency" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
 
     - "pt_immediate_return_cb": ${ True if pt_immediate_return == True and pt_return_person_choice != "later" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_immediate_return_pet": ${ True if pt_immediate_return == True and pt_return_person_choice == "Me" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_immediate_return_other": ${ True if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
-    - "pt_immediate_return_other_name": ${ pt_return_person.name.full(middle="full") if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
+    - "pt_immediate_return_other_name": ${ pt_return_person.name_full() if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
 
     - "order_to_appear_cb": ${ True if minor_kids_with_respondent and ((current_possession_of_children == False and return_children_to == "court" ) or (current_possession_of_children == True and res_appear_alone) or ( current_possession_of_children == False and return_children_to != "court" and res_appear_alone ) ) else '' }         
     - "appear_alone_cb": ${ True if minor_kids_with_respondent and (current_possession_of_children == True and res_appear_alone) or ( current_possession_of_children == False and return_children_to != "court" and res_appear_alone ) else '' }
@@ -5647,7 +5647,7 @@ attachment:
     - "property_transfer_present_police_name_known": ${ True if property_transfer_person == 'police' and property_transfer_present_cb == True and property_transfer_police != "" else '' }
     - "property_transfer_present_police_name": ${ property_transfer_police if property_transfer_person == 'police' and property_transfer_present_cb == True else '' }
     - "property_transfer_present_other_cb": ${ True if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
-    - "property_transfer_present_other_name": ${ other_transfer_property_person.name.full(middle="full") if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
+    - "property_transfer_present_other_name": ${ other_transfer_property_person.name_full() if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
     - "property_transfer_date": ${ property_transfer_date if property_transfer_know_date == True else '' }
     - "property_transfer_time": ${ format_time(property_transfer_time, format='h:mm') if property_transfer_know_date == True else ''  }
     - "property_transfer_time_am": ${ True if format_time(property_transfer_time, format='a') == "AM" and property_transfer_know_date == True else "" }
@@ -5665,7 +5665,7 @@ attachment:
     - "one_time_present_police_name_known": ${ True if res_property_transfer_person == 'police' and respondent_one_time_entry == True and res_property_transfer_police != "" else '' }
     - "one_time_present_police_name": ${ res_property_transfer_police if res_property_transfer_person == 'police' and respondent_one_time_entry == True else '' }
     - "one_time_present_other_cb": ${ True if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
-    - "one_time_present_person": ${ res_other_transfer_property_person.name.full(middle="full") if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
+    - "one_time_present_person": ${ res_other_transfer_property_person.name_full() if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
 
       # page 11    
     - "property_restrictions_cb": ${ True if restrict_other_property == True or restrict_elderly_petitioner_resources == "Yes" else "" }
@@ -5813,9 +5813,9 @@ attachment:
     - "phone_provider": ${ phone_provider if separate_phone_service else '' }
     - "phone_account_holder": |
         % if phone_account_holder == 'respondent' and separate_phone_service == True:
-        ${other_parties[0].name.full(middle="full")}
+        ${other_parties[0].name_full()}
         % elif phone_account_holder == 'other' and separate_phone_service == True:
-        ${ other_phone_account_holder.name.full(middle="full") }
+        ${ other_phone_account_holder.name_full() }
         % endif
     - "billing_phone_number": ${ phone_number_formatted(billing_phone_number) if separate_phone_service else '' }
     - "cell_number_1": ${ phone_number_formatted(cell_numbers[0].name.text) if separate_phone_service else '' }
@@ -5824,8 +5824,8 @@ attachment:
     - "cell_number_4": ${ phone_number_formatted(cell_numbers[3].name.text) if separate_phone_service else '' }
 
       # page 14    
-    - "petitioner_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-    - "preparer_name": ${ users[0].name.full(middle="full") }
+    - "petitioner_signature": ${ users[0].name_full() if e_signature else '' }
+    - "preparer_name": ${ users[0].name_full() }
     - "preparer_address_one_line": ${ users[0].address.on_one_line(bare=True) }
     - "preparer_phone": ${ phone_number_formatted(users[0].phone_number) }
     - "preparer_email": ${ users[0].email if users[0].email_notice else ""}
@@ -5840,20 +5840,20 @@ attachment:
   pdf template file: op_schools.pdf
   fields:
     - "county": ${ trial_court.address.county }
-    - "petitioner": ${ users[0].name.full(middle="full") }
+    - "petitioner": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
     - "obo_high_risk_adult_cb": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "respondent": ${other_parties[0].name_full()}
 
     - "school_1_kids": ${ comma_and_list(schools[0].kids_who_attend.true_values()) if stay_away_schools and schools[0].hide == True else '' }
     - "school_1_name": ${ schools[0].name if stay_away_schools and schools[0].hide == True else ''}
@@ -5887,20 +5887,20 @@ attachment:
   pdf template file: additional_incidents.pdf
   fields:
     - "county": ${ trial_court.address.county }
-    - "petitioner": ${ users[0].name.full(middle="full") }
+    - "petitioner": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
     - "obo_high_risk_adult_cb": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "respondent": ${other_parties[0].name_full()}
     - "incident_date_1": ${ incidents[4].date }
     - "incident_time_1": ${ incidents[4].time }
     - "incident_reason_1": ${ incidents[4].name.text }
@@ -5935,20 +5935,20 @@ attachment:
   pdf template file: additional_cases.pdf
   fields:
     - "county": ${ trial_court.address.county }
-    - "petitioner": ${ users[0].name.full(middle="full") }
+    - "petitioner": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
     - "obo_high_risk_adult_cb": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "respondent": ${other_parties[0].name_full()}
     - "case_number__1": ${ case_number }
       
     - "has_other_ops_yes": ${ has_other_ops == "Yes" }
@@ -6058,20 +6058,20 @@ attachment:
   pdf template file: affidavit_pt_supervisor.pdf
   fields:
     - "county": ${ trial_court.address.county }
-    - "petitioner__1": ${ users[0].name.full(middle="full") }
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "petitioner__1": ${ users[0].name_full() }
+    - "respondent": ${other_parties[0].name_full()}
     - "protect_petitioner": ${ protect_petitioner }
     - "protect_shared_kids": ${ protect_shared_kids }
-    - "shared_kids_list": ${ comma_and_list([person.name.full(middle="full") for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
+    - "shared_kids_list": ${ comma_and_list([person.name_full() for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
     - "protect_petitioner_kids": ${ protect_petitioner_kids }
     - "petitioner_kids_list": ${ petitioner_kids.full_names() if protect_petitioner_kids else '' }
     - "protect_dependent_adult": ${ protect_dependent_adult }
     - "protect_high_risk_adult": ${ protect_high_risk_adult }
     - "protect_other_hh_members": ${ protect_other_hh_members }
     - "other_hh_members_list": ${ other_hh_members.full_names() if protect_other_hh_members else '' }
-    - "dependent_adult": ${ dependent_adult.name.full(middle="full") if protect_dependent_adult else '' }
-    - "high_risk_adult": ${ high_risk_adult.name.full(middle="full") if protect_high_risk_adult else '' }
-    - "pt_supervisor_name": ${ pt_supervisor.name.full(middle="full") if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
+    - "dependent_adult": ${ dependent_adult.name_full() if protect_dependent_adult else '' }
+    - "high_risk_adult": ${ high_risk_adult.name_full() if protect_high_risk_adult else '' }
+    - "pt_supervisor_name": ${ pt_supervisor.name_full() if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
 
 ---
 attachment:
@@ -6083,11 +6083,11 @@ attachment:
   pdf template file: efiling_exemption.pdf
   fields:
     - "county": ${ trial_court.address.county }
-    - "petitioner__1": ${ users[0].name.full(middle="full") }
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "petitioner__1": ${ users[0].name_full() }
+    - "respondent": ${other_parties[0].name_full()}
     - "reason_dv": ${ True }
-    - "e_signature": ${ users[0].name.full(middle="full") if e_signature else '' }
-    - "petitioner__2": ${ users[0].name.full(middle="full") }
+    - "e_signature": ${ users[0].name_full() if e_signature else '' }
+    - "petitioner__2": ${ users[0].name_full() }
     - "user_address_one_line": ${ users[0].address.on_one_line(bare=True) }
     - "user_phone_number": ${ phone_number_formatted(users[0].phone_number) }
     - "user_email": ${ users[0].email if users[0].email_notice else ""}
@@ -6102,16 +6102,16 @@ attachment:
   fields:
     - "county__2": ${ trial_court.address.county }
     - "county": ${ trial_court.address.county }
-    - "petitioner": ${ users[0].name.full(middle="full") }
+    - "petitioner": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
     - "obo_high_risk_adult_cb": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
@@ -6119,25 +6119,25 @@ attachment:
     - "obo_high_risk_adult_cb_2": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name_2": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
-    - "respondent__1": ${other_parties[0].name.full(middle="full")}
-    - "petitioner__2": ${ users[0].name.full(middle="full") }
-    - "petitioner__3": ${ users[0].name.full(middle="full") }
-    - "respondent__3": ${other_parties[0].name.full(middle="full")}
-    - "respondent__4": ${other_parties[0].name.full(middle="full")}
+    - "respondent__1": ${other_parties[0].name_full()}
+    - "petitioner__2": ${ users[0].name_full() }
+    - "petitioner__3": ${ users[0].name_full() }
+    - "respondent__3": ${other_parties[0].name_full()}
+    - "respondent__4": ${other_parties[0].name_full()}
     - "case_number__1": ${ case_number }
     - "case_number__2": ${ case_number }
     - "case_number__3": ${ case_number }
     - "case_number__4": ${ case_number }
     - "case_number__5": ${ case_number }
-    - "respondent__2": ${other_parties[0].name.full(middle="full")}
+    - "respondent__2": ${other_parties[0].name_full()}
     - "service_address_line_1": |
         % if service_address_choice == "other":
         ${ service_address.line_one(bare=True) }
@@ -6212,49 +6212,49 @@ attachment:
     - "civil_proceeding": True
     - "petitioner": |
         % if users[0].birthdate != "":
-        ${ users[0].name.full(middle="full") + ", (DOB: " + users[0].birthdate + ")" }
+        ${ users[0].name_full() + ", (DOB: " + users[0].birthdate + ")" }
         % else:
-        ${ users[0].name.full(middle="full") }
+        ${ users[0].name_full() }
         % endif
     - "petitioner__2": |
         % if protect_petitioner and protect_obo_minor: 
-        ${ users[0].name.full(middle="full") + " and on behalf of minor: " + obo_minor.name.full(middle="full")}
+        ${ users[0].name_full() + " and on behalf of minor: " + obo_minor.name_full()}
         % elif protect_petitioner:
-        ${ users[0].name.full(middle="full") }
+        ${ users[0].name_full() }
         % elif protect_obo_minor:
-        ${ "On behalf of minor: " + obo_minor.name.full(middle="full")}
+        ${ "On behalf of minor: " + obo_minor.name_full()}
         % else:
         ${""}
-        % endif    - "petitioner__3": ${ users[0].name.full(middle="full") }
+        % endif    - "petitioner__3": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
     - "obo_high_risk_adult_cb": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
     - "respondent": |
         % if knows_respondent_dob == "exact" and other_parties[0].birthdate != "":
-        ${ other_parties[0].name.full(middle="full") + ", (DOB: " + other_parties[0].birthdate + ")" }
+        ${ other_parties[0].name_full() + ", (DOB: " + other_parties[0].birthdate + ")" }
         % else:
-        ${ other_parties[0].name.full(middle="full") }
+        ${ other_parties[0].name_full() }
         % endif
     - "protect_petitioner": ${ protect_petitioner }
     - "protect_shared_kids": ${ protect_shared_kids }
-    - "shared_kids_list": ${ comma_and_list([person.name.full(middle="full") for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
+    - "shared_kids_list": ${ comma_and_list([person.name_full() for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
     - "protect_petitioner_kids": ${ protect_petitioner_kids }
     - "petitioner_kids_list": ${ petitioner_kids.full_names() if protect_petitioner_kids else '' }
     - "protect_dependent_adult": ${ protect_dependent_adult }
     - "protect_high_risk_adult": ${ protect_high_risk_adult }
     - "protect_other_hh_members": ${ protect_other_hh_members }
     - "other_hh_members_list": ${ other_hh_members.full_names() if protect_other_hh_members else '' }
-    - "dependent_adult": ${ dependent_adult.name.full(middle="full") if protect_dependent_adult else '' }
-    - "high_risk_adult": ${ high_risk_adult.name.full(middle="full") if protect_high_risk_adult else '' }    
+    - "dependent_adult": ${ dependent_adult.name_full() if protect_dependent_adult else '' }
+    - "high_risk_adult": ${ high_risk_adult.name_full() if protect_high_risk_adult else '' }    
       # page 2
     - "show_address": ${ not hide_address }
     - "hide_address": ${ hide_address }
@@ -6589,7 +6589,7 @@ attachment:
     - "respondent_one_time_entry": ${ True if respondent_one_time_entry == True else '' }
     - "respondent_one_time_entry_police": ${ True if respondent_one_time_entry == True and property_transfer_person == 'police' and property_transfer_present_cb == True else '' }
     - "respondent_one_time_entry_other_cb": ${ True if respondent_one_time_entry == True and property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
-    - "respondent_one_time_entry_name": ${ other_transfer_property_person.name.full(middle="full") if respondent_one_time_entry == True and property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
+    - "respondent_one_time_entry_name": ${ other_transfer_property_person.name_full() if respondent_one_time_entry == True and property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
 
 
     - "same_school_not_attend": ${ True if (same_school and same_school_restrictions == "not attend") else ""}
@@ -6604,7 +6604,7 @@ attachment:
       # page 5
     
     - "care_and_possession_of_children": ${ minor_kids_with_respondent } 
-    - "shared_kids_1_name": ${ shared_kids[0].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_1_name": ${ shared_kids[0].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_1_age": ${ shared_kids[0].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_1_state": ${ shared_kids[0].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_1_pet_par": ${ True if minor_kids_with_respondent and shared_kids[0].pet_parentage == True else "" }
@@ -6612,7 +6612,7 @@ attachment:
     - "shared_kids_1_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[0].pet_parentage == None and shared_kids[0].res_parentage == None) else "" }
     - "shared_kids_1_include_yes": ${ shared_kids[0].protect if minor_kids_with_respondent else '' }
     - "shared_kids_1_include_no": ${ True if minor_kids_with_respondent and shared_kids[0].protect == False else '' }
-    - "shared_kids_2_name": ${ shared_kids[1].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_2_name": ${ shared_kids[1].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_2_age": ${ shared_kids[1].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_2_state": ${ shared_kids[1].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_2_pet_par": ${ True if minor_kids_with_respondent and shared_kids[1].pet_parentage == True else "" }
@@ -6620,7 +6620,7 @@ attachment:
     - "shared_kids_2_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[1].pet_parentage == None and shared_kids[1].res_parentage == None) else "" }
     - "shared_kids_2_include_yes": ${ shared_kids[1].protect if minor_kids_with_respondent else '' }
     - "shared_kids_2_include_no": ${ True if minor_kids_with_respondent and shared_kids[1].protect == False else '' }
-    - "shared_kids_3_name": ${ shared_kids[2].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_3_name": ${ shared_kids[2].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_3_age": ${ shared_kids[2].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_3_state": ${ shared_kids[2].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_3_pet_par": ${ True if minor_kids_with_respondent and shared_kids[2].pet_parentage == True else "" }
@@ -6628,7 +6628,7 @@ attachment:
     - "shared_kids_3_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[2].pet_parentage == None and shared_kids[2].res_parentage == None) else "" }
     - "shared_kids_3_include_yes": ${ shared_kids[2].protect if minor_kids_with_respondent else '' }
     - "shared_kids_3_include_no": ${ True if minor_kids_with_respondent and shared_kids[2].protect == False else '' }
-    - "shared_kids_4_name": ${ shared_kids[3].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_4_name": ${ shared_kids[3].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_4_age": ${ shared_kids[3].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_4_state": ${ shared_kids[3].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_4_pet_par": ${ True if minor_kids_with_respondent and shared_kids[3].pet_parentage == True else "" }
@@ -6636,7 +6636,7 @@ attachment:
     - "shared_kids_4_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[3].pet_parentage == None and shared_kids[3].res_parentage == None) else "" }
     - "shared_kids_4_include_yes": ${ shared_kids[3].protect if minor_kids_with_respondent else '' }
     - "shared_kids_4_include_no": ${ True if minor_kids_with_respondent and shared_kids[3].protect == False else '' }
-    - "shared_kids_5_name": ${ shared_kids[4].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_5_name": ${ shared_kids[4].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_5_age": ${ shared_kids[4].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_5_state": ${ shared_kids[4].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_5_pet_par": ${ True if minor_kids_with_respondent and shared_kids[4].pet_parentage == True else "" }
@@ -6644,7 +6644,7 @@ attachment:
     - "shared_kids_5_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[4].pet_parentage == None and shared_kids[4].res_parentage == None) else "" }
     - "shared_kids_5_include_yes": ${ shared_kids[4].protect if minor_kids_with_respondent else '' }
     - "shared_kids_5_include_no": ${ True if minor_kids_with_respondent and shared_kids[4].protect == False else '' }
-    - "shared_kids_6_name": ${ shared_kids[5].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_6_name": ${ shared_kids[5].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_6_age": ${ shared_kids[5].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_6_state": ${ shared_kids[5].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_6_pet_par": ${ True if minor_kids_with_respondent and shared_kids[5].pet_parentage == True else "" }
@@ -6661,7 +6661,7 @@ attachment:
     - "caretaker_petitioner": ${ True if (primary_caretaker == "petitioner" and minor_kids_with_respondent) else '' }
     - "caretaker_respondent": ${ True if (primary_caretaker == "respondent" and minor_kids_with_respondent) else '' }
     - "caretaker_other": ${ True if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
-    - "other_caretaker_name": ${ other_caretaker.name.full(middle="full") if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
+    - "other_caretaker_name": ${ other_caretaker.name_full() if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
     - "other_caretaker_address": ${ other_caretaker.address.on_one_line(bare=True) if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
     - "care_and_possession_cb": ${ True if physical_care_of_children or return_children_to == "petitioner" or return_children_to == "other" or no_removal_school or ((schools[0].hide or schools[1].hide) and stay_away_schools and minor_kids_with_respondent) else '' }
 
@@ -6670,7 +6670,7 @@ attachment:
     - "return_children_possession": ${ True if (return_children_to == "petitioner" or return_children_to == "other") and minor_kids_with_respondent else '' }
     - "return_children_petitioner_cb": ${ True if return_children_to == "petitioner" and minor_kids_with_respondent else '' }
     - "return_children_other_cb": ${ True if return_children_to == "other" and minor_kids_with_respondent else '' }    
-    - "return_children_other_person": ${ return_children_other_person.name.full(middle="full") if return_children_to == "other" and minor_kids_with_respondent else '' }
+    - "return_children_other_person": ${ return_children_other_person.name_full() if return_children_to == "other" and minor_kids_with_respondent else '' }
     - "return_children_location": ${ return_children_location.on_one_line(bare=True) if knows_return_children_details and return_children_to == "other" and minor_kids_with_respondent else "" }
 
     
@@ -6819,7 +6819,7 @@ attachment:
         % elif pt_transportation == "respondent" and (parenting_time == "restrict" or parenting_time == "grant"):
         ${ "Respondent" }
         % elif pt_transportation == "other" and (parenting_time == "restrict" or parenting_time == "grant"):
-        ${ pt_transportation_person.name.full(middle="full") }
+        ${ pt_transportation_person.name_full() }
         % else:
         ${ "" }
         % endif
@@ -6867,14 +6867,14 @@ attachment:
         % endif
         
     - "pt_supervised": ${ True if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
-    - "pt_supervisor_name": ${ pt_supervisor.name.full(middle="full") if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
+    - "pt_supervisor_name": ${ pt_supervisor.name_full() if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_supervised_center_cb": ${ True if pt_supervised == True and pt_supervisor_type == "agency" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_visitation_center_name": ${ pt_visitation_center_name  if pt_supervised == True and pt_supervisor_type == "agency" and (parenting_time == "restrict" or parenting_time == "grant") and pt_visitation_center_name != "" else "" }    
 
     - "pt_immediate_return_cb": ${ True if pt_immediate_return == True and pt_return_person_choice != "later" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_immediate_return_pet": ${ True if pt_immediate_return == True and pt_return_person_choice == "Me" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_immediate_return_other": ${ True if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
-    - "pt_immediate_return_other_name": ${ pt_return_person.name.full(middle="full") if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
+    - "pt_immediate_return_other_name": ${ pt_return_person.name_full() if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
 
     - "no_conceal_children_cb": ${ True if no_conceal_children and minor_kids_with_respondent else '' }
     
@@ -6952,7 +6952,7 @@ attachment:
         % if return_property_person == "petitioner":
         ${ "Petitioner" }
         % elif return_property_person == 'other':
-        ${ other_return_property_person.name.full(middle="full") }
+        ${ other_return_property_person.name_full() }
         % endif
         % endif
 
@@ -6969,7 +6969,7 @@ attachment:
     - "property_transfer_present_police_name_known": ${ True if property_transfer_person == 'police' and property_transfer_present_cb == True and property_transfer_police != "" else '' }
     - "property_transfer_present_police_name": ${ property_transfer_police if property_transfer_person == 'police' and property_transfer_present_cb == True else '' }
     - "property_transfer_present_other_cb": ${ True if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
-    - "property_transfer_present_other_name": ${ other_transfer_property_person.name.full(middle="full") if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
+    - "property_transfer_present_other_name": ${ other_transfer_property_person.name_full() if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
     - "property_transfer_date": ${ property_transfer_date if property_transfer_know_date == True else '' }
     - "property_transfer_time": ${ format_time(property_transfer_time, format='h:mm') if property_transfer_know_date == True else ''  }
     - "property_transfer_time_am": ${ True if format_time(property_transfer_time, format='a') == "AM" and property_transfer_know_date == True else "" }
@@ -6987,7 +6987,7 @@ attachment:
     - "one_time_present_police_name_known": ${ True if res_property_transfer_person == 'police' and respondent_one_time_entry == True and res_property_transfer_police != "" else '' }
     - "one_time_present_police_name": ${ res_property_transfer_police if res_property_transfer_person == 'police' and respondent_one_time_entry == True else '' }
     - "one_time_present_other_cb": ${ True if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
-    - "one_time_present_person": ${ res_other_transfer_property_person.name.full(middle="full") if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
+    - "one_time_present_person": ${ res_other_transfer_property_person.name_full() if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
     
     - "property_restrictions_cb": ${ True if restrict_other_property == True or restrict_elderly_petitioner_resources == "Yes" else "" }
     - "restrict_property_cb": ${ True if restrict_other_property == True else "" }
@@ -7034,9 +7034,9 @@ attachment:
     - "phone_provider": ${ phone_provider if separate_phone_service else '' }
     - "phone_account_holder": |
         % if phone_account_holder == 'respondent' and separate_phone_service == True:
-        ${other_parties[0].name.full(middle="full")}
+        ${other_parties[0].name_full()}
         % elif phone_account_holder == 'other' and separate_phone_service == True:
-        ${ other_phone_account_holder.name.full(middle="full") }
+        ${ other_phone_account_holder.name_full() }
         % endif
     - "billing_phone_number": ${ phone_number_formatted(billing_phone_number) if separate_phone_service else '' }
     - "cell_number_1": ${ phone_number_formatted(cell_numbers[0].name.text) if separate_phone_service else '' }
@@ -7085,49 +7085,49 @@ attachment:
     - "civil_proceeding": True
     - "petitioner": |
         % if users[0].birthdate != "":
-        ${ users[0].name.full(middle="full") + ", (DOB: " + users[0].birthdate + ")" }
+        ${ users[0].name_full() + ", (DOB: " + users[0].birthdate + ")" }
         % else:
-        ${ users[0].name.full(middle="full") }
+        ${ users[0].name_full() }
         % endif
     - "petitioner__2": |
         % if protect_petitioner and protect_obo_minor: 
-        ${ users[0].name.full(middle="full") + " and on behalf of minor: " + obo_minor.name.full(middle="full")}
+        ${ users[0].name_full() + " and on behalf of minor: " + obo_minor.name_full()}
         % elif protect_petitioner:
-        ${ users[0].name.full(middle="full") }
+        ${ users[0].name_full() }
         % elif protect_obo_minor:
-        ${ "On behalf of minor: " + obo_minor.name.full(middle="full")}
+        ${ "On behalf of minor: " + obo_minor.name_full()}
         % else:
         ${""}
-        % endif    - "petitioner__3": ${ users[0].name.full(middle="full") }
+        % endif    - "petitioner__3": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
     - "obo_high_risk_adult_cb": ${ True if protect_high_risk_adult else '' }
     - "obo_child_or_adult_name": |
         % if protect_obo_minor and protect_high_risk_adult:
-        ${ obo_minor.name.full(middle="full") }, ${ high_risk_adult.name.full(middle="full") }
+        ${ obo_minor.name_full() }, ${ high_risk_adult.name_full() }
         % elif protect_obo_minor:
-        ${ obo_minor.name.full(middle="full") }
+        ${ obo_minor.name_full() }
         % elif protect_high_risk_adult:
-        ${ high_risk_adult.name.full(middle="full") }
+        ${ high_risk_adult.name_full() }
         % else:
         ${""}
         % endif
     - "respondent": |
         % if knows_respondent_dob == "exact" and other_parties[0].birthdate != "":
-        ${ other_parties[0].name.full(middle="full") + ", (DOB: " + other_parties[0].birthdate + ")" }
+        ${ other_parties[0].name_full() + ", (DOB: " + other_parties[0].birthdate + ")" }
         % else:
-        ${ other_parties[0].name.full(middle="full") }
+        ${ other_parties[0].name_full() }
         % endif
     - "protect_petitioner": ${ protect_petitioner }
     - "protect_shared_kids": ${ protect_shared_kids }
-    - "shared_kids_list": ${ comma_and_list([person.name.full(middle="full") for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
+    - "shared_kids_list": ${ comma_and_list([person.name_full() for person in shared_kids if person.protect == True]) if (minor_kids_with_respondent == True and shared_kids.number() > 0 and protect_shared_kids == True) else "" }
     - "protect_petitioner_kids": ${ protect_petitioner_kids }
     - "petitioner_kids_list": ${ petitioner_kids.full_names() if protect_petitioner_kids else '' }
     - "protect_dependent_adult": ${ protect_dependent_adult }
     - "protect_high_risk_adult": ${ protect_high_risk_adult }
     - "protect_other_hh_members": ${ protect_other_hh_members }
     - "other_hh_members_list": ${ other_hh_members.full_names() if protect_other_hh_members else '' }
-    - "dependent_adult": ${ dependent_adult.name.full(middle="full") if protect_dependent_adult else '' }
-    - "high_risk_adult": ${ high_risk_adult.name.full(middle="full") if protect_high_risk_adult else '' }    
+    - "dependent_adult": ${ dependent_adult.name_full() if protect_dependent_adult else '' }
+    - "high_risk_adult": ${ high_risk_adult.name_full() if protect_high_risk_adult else '' }    
       
       # page 2
     - "show_address": ${ not hide_address }
@@ -7459,7 +7459,7 @@ attachment:
     - "respondent_one_time_entry": ${ True if respondent_one_time_entry == True else '' }
     - "respondent_one_time_entry_police": ${ True if respondent_one_time_entry == True and property_transfer_person == 'police' and property_transfer_present_cb == True else '' }
     - "respondent_one_time_entry_other_cb": ${ True if respondent_one_time_entry == True and property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
-    - "respondent_one_time_entry_name": ${ other_transfer_property_person.name.full(middle="full") if respondent_one_time_entry == True and property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
+    - "respondent_one_time_entry_name": ${ other_transfer_property_person.name_full() if respondent_one_time_entry == True and property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
 
     - "same_school_restrictions": ${ True if (same_school and same_school_restrictions != "none") else ""} 
     - "same_school_name": ${ same_school_name if (same_school and same_school_restrictions != "none") else ""}
@@ -7483,7 +7483,7 @@ attachment:
     
     - "care_and_possession_of_children": ${ minor_kids_with_respondent } 
     - "minor_kids_with_respondent": ${ minor_kids_with_respondent }
-    - "shared_kids_1_name": ${ shared_kids[0].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_1_name": ${ shared_kids[0].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_1_age": ${ shared_kids[0].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_1_state": ${ shared_kids[0].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_1_pet_par": ${ True if minor_kids_with_respondent and shared_kids[0].pet_parentage == True else "" }
@@ -7491,7 +7491,7 @@ attachment:
     - "shared_kids_1_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[0].pet_parentage == None and shared_kids[0].res_parentage == None) else "" }
     - "shared_kids_1_include_yes": ${ shared_kids[0].protect if minor_kids_with_respondent else '' }
     - "shared_kids_1_include_no": ${ True if minor_kids_with_respondent and shared_kids[0].protect == False else '' }
-    - "shared_kids_2_name": ${ shared_kids[1].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_2_name": ${ shared_kids[1].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_2_age": ${ shared_kids[1].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_2_state": ${ shared_kids[1].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_2_pet_par": ${ True if minor_kids_with_respondent and shared_kids[1].pet_parentage == True else "" }
@@ -7499,7 +7499,7 @@ attachment:
     - "shared_kids_2_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[1].pet_parentage == None and shared_kids[1].res_parentage == None) else "" }
     - "shared_kids_2_include_yes": ${ shared_kids[1].protect if minor_kids_with_respondent else '' }
     - "shared_kids_2_include_no": ${ True if minor_kids_with_respondent and shared_kids[1].protect == False else '' }
-    - "shared_kids_3_name": ${ shared_kids[2].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_3_name": ${ shared_kids[2].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_3_age": ${ shared_kids[2].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_3_state": ${ shared_kids[2].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_3_pet_par": ${ True if minor_kids_with_respondent and shared_kids[2].pet_parentage == True else "" }
@@ -7507,7 +7507,7 @@ attachment:
     - "shared_kids_3_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[2].pet_parentage == None and shared_kids[2].res_parentage == None) else "" }
     - "shared_kids_3_include_yes": ${ shared_kids[2].protect if minor_kids_with_respondent else '' }
     - "shared_kids_3_include_no": ${ True if minor_kids_with_respondent and shared_kids[2].protect == False else '' }
-    - "shared_kids_4_name": ${ shared_kids[3].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_4_name": ${ shared_kids[3].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_4_age": ${ shared_kids[3].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_4_state": ${ shared_kids[3].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_4_pet_par": ${ True if minor_kids_with_respondent and shared_kids[3].pet_parentage == True else "" }
@@ -7515,7 +7515,7 @@ attachment:
     - "shared_kids_4_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[3].pet_parentage == None and shared_kids[3].res_parentage == None) else "" }
     - "shared_kids_4_include_yes": ${ shared_kids[3].protect if minor_kids_with_respondent else '' }
     - "shared_kids_4_include_no": ${ True if minor_kids_with_respondent and shared_kids[3].protect == False else '' }
-    - "shared_kids_5_name": ${ shared_kids[4].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_5_name": ${ shared_kids[4].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_5_age": ${ shared_kids[4].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_5_state": ${ shared_kids[4].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_5_pet_par": ${ True if minor_kids_with_respondent and shared_kids[4].pet_parentage == True else "" }
@@ -7523,7 +7523,7 @@ attachment:
     - "shared_kids_5_idk_par": ${ True if minor_kids_with_respondent and (shared_kids[4].pet_parentage == None and shared_kids[4].res_parentage == None) else "" }
     - "shared_kids_5_include_yes": ${ shared_kids[4].protect if minor_kids_with_respondent else '' }
     - "shared_kids_5_include_no": ${ True if minor_kids_with_respondent and shared_kids[4].protect == False else '' }
-    - "shared_kids_6_name": ${ shared_kids[5].name.full(middle="full") if  minor_kids_with_respondent else '' }
+    - "shared_kids_6_name": ${ shared_kids[5].name_full() if  minor_kids_with_respondent else '' }
     - "shared_kids_6_age": ${ shared_kids[5].age_in_years() if minor_kids_with_respondent else '' }
     - "shared_kids_6_state": ${ shared_kids[5].address.state if minor_kids_with_respondent else '' }
     - "shared_kids_6_pet_par": ${ True if minor_kids_with_respondent and shared_kids[5].pet_parentage == True else "" }
@@ -7540,7 +7540,7 @@ attachment:
     - "caretaker_petitioner": ${ True if (primary_caretaker == "petitioner" and minor_kids_with_respondent) else '' }
     - "caretaker_respondent": ${ True if (primary_caretaker == "respondent" and minor_kids_with_respondent) else '' }
     - "caretaker_other": ${ True if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
-    - "other_caretaker_name": ${ other_caretaker.name.full(middle="full") if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
+    - "other_caretaker_name": ${ other_caretaker.name_full() if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
     - "other_caretaker_address": ${ other_caretaker.address.on_one_line(bare=True) if (primary_caretaker == "other" and minor_kids_with_respondent) else '' }
 
     - "care_and_possession_cb": ${ True if physical_care_of_children or return_children_to == "petitioner" or return_children_to == "other" or no_removal_school or ((schools[0].hide or schools[1].hide) and stay_away_schools and minor_kids_with_respondent) else '' }
@@ -7550,7 +7550,7 @@ attachment:
     - "return_children_possession": ${ True if (return_children_to == "petitioner" or return_children_to == "other") and minor_kids_with_respondent else '' }
     - "return_children_petitioner_cb": ${ True if return_children_to == "petitioner" and minor_kids_with_respondent else '' }
     - "return_children_other_cb": ${ True if return_children_to == "other" and minor_kids_with_respondent else '' }    
-    - "return_children_other_person": ${ return_children_other_person.name.full(middle="full") if return_children_to == "other" and minor_kids_with_respondent else '' }
+    - "return_children_other_person": ${ return_children_other_person.name_full() if return_children_to == "other" and minor_kids_with_respondent else '' }
     - "return_children_location": ${ return_children_location.on_one_line(bare=True) if knows_return_children_details and return_children_to == "other" and minor_kids_with_respondent else "" }
 
     - "no_removal_school": ${ True if no_removal_school and minor_kids_with_respondent else '' }
@@ -7701,7 +7701,7 @@ attachment:
         % elif pt_transportation == "respondent" and (parenting_time == "restrict" or parenting_time == "grant"):
         ${ "Respondent" }
         % elif pt_transportation == "other" and (parenting_time == "restrict" or parenting_time == "grant"):
-        ${ pt_transportation_person.name.full(middle="full") }
+        ${ pt_transportation_person.name_full() }
         % else:
         ${ "" }
         % endif
@@ -7748,14 +7748,14 @@ attachment:
         ${ "" }
         % endif
     - "pt_supervised": ${ True if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
-    - "pt_supervisor_name": ${ pt_supervisor.name.full(middle="full") if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
+    - "pt_supervisor_name": ${ pt_supervisor.name_full() if pt_supervised == True and pt_supervisor_type == "person" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_supervised_center_cb": ${ True if pt_supervised == True and pt_supervisor_type == "agency" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_visitation_center_name": ${ pt_visitation_center_name  if pt_supervised == True and pt_supervisor_type == "agency" and (parenting_time == "restrict" or parenting_time == "grant") and pt_visitation_center_name != "" else "" }    
 
     - "pt_immediate_return_cb": ${ True if pt_immediate_return == True and pt_return_person_choice != "later" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_immediate_return_pet": ${ True if pt_immediate_return == True and pt_return_person_choice == "Me" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
     - "pt_immediate_return_other": ${ True if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
-    - "pt_immediate_return_other_name": ${ pt_return_person.name.full(middle="full") if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
+    - "pt_immediate_return_other_name": ${ pt_return_person.name_full() if pt_immediate_return == True and pt_return_person_choice == "other" and (parenting_time == "restrict" or parenting_time == "grant") else "" }
 
     - "no_conceal_children_cb": ${ True if no_conceal_children and minor_kids_with_respondent else '' }
 
@@ -7834,7 +7834,7 @@ attachment:
         % if return_property_person == "petitioner":
         ${ "Petitioner" }
         % elif return_property_person == 'other':
-        ${ other_return_property_person.name.full(middle="full") }
+        ${ other_return_property_person.name_full() }
         % endif
         % endif
     
@@ -7849,7 +7849,7 @@ attachment:
     - "property_transfer_present_police_name_known": ${ True if property_transfer_person == 'police' and property_transfer_present_cb == True and property_transfer_police != "" else '' }
     - "property_transfer_present_police_name": ${ property_transfer_police if property_transfer_person == 'police' and property_transfer_present_cb == True else '' }
     - "property_transfer_present_other_cb": ${ True if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
-    - "property_transfer_present_other_name": ${ other_transfer_property_person.name.full(middle="full") if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
+    - "property_transfer_present_other_name": ${ other_transfer_property_person.name_full() if property_transfer_person == 'other' and property_transfer_present_cb == True else '' }
     - "property_transfer_date": ${ property_transfer_date if property_transfer_know_date == True else '' }
     - "property_transfer_time": ${ format_time(property_transfer_time, format='h:mm') if property_transfer_know_date == True else ''  }
     - "property_transfer_time_am": ${ True if format_time(property_transfer_time, format='a') == "AM" and property_transfer_know_date == True else "" }
@@ -7867,7 +7867,7 @@ attachment:
     - "one_time_present_police_name_known": ${ True if res_property_transfer_person == 'police' and respondent_one_time_entry == True and res_property_transfer_police != "" else '' }
     - "one_time_present_police_name": ${ res_property_transfer_police if res_property_transfer_person == 'police' and respondent_one_time_entry == True else '' }
     - "one_time_present_other_cb": ${ True if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
-    - "one_time_present_person": ${ res_other_transfer_property_person.name.full(middle="full") if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
+    - "one_time_present_person": ${ res_other_transfer_property_person.name_full() if res_property_transfer_person == 'other' and respondent_one_time_entry == True else '' }
 
      # page 9    
     - "property_restrictions_cb": ${ True if restrict_other_property == True or restrict_elderly_petitioner_resources == "Yes" else "" }
@@ -8012,9 +8012,9 @@ attachment:
     - "phone_provider": ${ phone_provider if separate_phone_service else '' }
     - "phone_account_holder": |
         % if phone_account_holder == 'respondent' and separate_phone_service == True:
-        ${other_parties[0].name.full(middle="full")}
+        ${other_parties[0].name_full()}
         % elif phone_account_holder == 'other' and separate_phone_service == True:
-        ${ other_phone_account_holder.name.full(middle="full") }
+        ${ other_phone_account_holder.name_full() }
         % endif
     - "billing_phone_number": ${ phone_number_formatted(billing_phone_number) if separate_phone_service else '' }
     - "cell_number_1": ${ phone_number_formatted(cell_numbers[0].name.text) if separate_phone_service else '' }
@@ -8061,15 +8061,15 @@ attachment:
   fields:
     - "petitioner__1": |
         % if users[0].birthdate != "":
-        ${ users[0].name.full(middle="full") + ", (DOB: " + users[0].birthdate + ")" }
+        ${ users[0].name_full() + ", (DOB: " + users[0].birthdate + ")" }
         % else:
-        ${ users[0].name.full(middle="full") }
+        ${ users[0].name_full() }
         % endif
     - "respondent": |
         % if knows_respondent_dob == "exact" and other_parties[0].birthdate != "":
-        ${ other_parties[0].name.full(middle="full") + ", (DOB: " + other_parties[0].birthdate + ")" }
+        ${ other_parties[0].name_full() + ", (DOB: " + other_parties[0].birthdate + ")" }
         % else:
-        ${ other_parties[0].name.full(middle="full") }
+        ${ other_parties[0].name_full() }
         % endif
     - "civil_proceeding": ${ True }
 
@@ -8084,7 +8084,7 @@ attachment:
     - "previous_cook_case_judge": ${ previous_cook_case_judge if previous_cook_case_type == "divorce" or previous_cook_case_type == "parentage" else '' }
 
     - "pro_se_cb": ${ True }
-    - "petitioner__2": ${ users[0].name.full(middle="full") }
+    - "petitioner__2": ${ users[0].name_full() }
     - "preparer_address_line_1": ${ users[0].address.line_one(bare=True) }
     - "petitioner_city": ${ users[0].address.city }
     - "petitioner_state": ${ users[0].address.state }
@@ -8101,7 +8101,7 @@ attachment:
   editable: False
   pdf template file: cook_sheriff_info_sheet.pdf
   fields:
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "respondent": ${other_parties[0].name_full()}
     - "alias_names": ${ alias_names}
     - "respondent_race": ${ respondent_race_other if other_parties[0].race == 'other' else other_parties[0].race }
     - "respondent_dob": |
@@ -8247,7 +8247,7 @@ attachment:
     - "cook_vehicle_plate": ${ cook_vehicle_plate }
     - "cook_vehicle_state": ${ state_name(cook_vehicle_state) }
 
-    - "preparer_name": ${ users[0].name.full(middle="full") }
+    - "preparer_name": ${ users[0].name_full() }
     - "preparer_phone": ${ phone_number_formatted(users[0].phone_number) }
 ---
 attachment:
@@ -8270,9 +8270,9 @@ attachment:
   pdf template file: op_warrant_info_sheet.pdf
   fields:
     - "county": ${ trial_court.address.county }
-    - "petitioner": ${ users[0].name.full(middle="full") }
+    - "petitioner": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "respondent": ${other_parties[0].name_full()}
     - "case_number__1": ${ case_number }
     - "petitioner_notice_phone": ${ phone_number_formatted(users[0].phone_number) }
     - "petitioner_notice_email": ${ users[0].email if users[0].email_notice else "" }
@@ -8321,7 +8321,7 @@ attachment:
   pdf template file: op_warrant.pdf
   fields:
     - "county": ${ trial_court.address.county }
-    - "petitioner": ${ users[0].name.full(middle="full") }
+    - "petitioner": ${ users[0].name_full() }
     - "obo_minor_cb": ${ True if protect_obo_minor else '' }
-    - "respondent": ${other_parties[0].name.full(middle="full")}
+    - "respondent": ${other_parties[0].name_full()}
     - "case_number__1": ${ case_number }


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>